### PR TITLE
Add initial support for nose as a test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ it's the command: `rspec spec/path/to/file_spec.rb:123`.
   * You can override the default command (`bundle exec cucumber`) using the
     `g:neoterm_cucumber_lib_cmd`
 * minitest
-* go-lang test (partially see #8)
 * go-lang test ([partially implemented](https://github.com/kassio/neoterm/pull/8))
 * nose ([partially implemented](https://github.com/kassio/neoterm/pull/9))
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ it's the command: `rspec spec/path/to/file_spec.rb:123`.
 * cucumber
 * minitest
 * go-lang test (partially see #8)
+* nose
 
 ## REPL
 

--- a/autoload/neoterm/test/nose.vim
+++ b/autoload/neoterm/test/nose.vim
@@ -1,0 +1,8 @@
+function! neoterm#test#nose#run(scope)
+  let command = 'nosetests'
+  if a:scope == 'file'
+    let command .= ' ' . expand('%:p')
+  endif
+
+  return command
+endfunction

--- a/ftdetect/nose.vim
+++ b/ftdetect/nose.vim
@@ -1,2 +1,3 @@
 aug neoterm_test_nose
   au VimEnter,BufRead,BufNewFile *.py, call neoterm#test#libs#add('nose')
+aug END

--- a/ftdetect/nose.vim
+++ b/ftdetect/nose.vim
@@ -1,0 +1,2 @@
+aug neoterm_test_nose
+  au VimEnter,BufRead,BufNewFile *.py, call neoterm#test#libs#add('nose')


### PR DESCRIPTION
Still TODO is support for a scope for the class or method under cursor, syntax for nose is `nosetests <filename>:<class>.<method>`