### PR TITLE
Add pry as a REPL source

### DIFF
--- a/ftdetect/ruby_repl.vim
+++ b/ftdetect/ruby_repl.vim
@@ -2,7 +2,9 @@ aug neoterm_ruby_repl
   au VimEnter,BufRead,BufNewFile *
         \ if filereadable('config/application.rb') |
         \   let g:neoterm_repl_command = 'bundle exec rails console' |
-        \ elseif &ft == 'ruby' |
+        \ elseif executable('pry') |
+        \   let g:neoterm_repl_command = 'pry' |
+        \ elseif executable('irb') |
         \   let g:neoterm_repl_command = 'irb' |
         \ endif
 aug END


### PR DESCRIPTION
Some people (including myself) enjoy pry. This adds pry as a REPL source for Ruby.