### PR TITLE
Respect user's SHELL variable when executing term commands

### DIFF
--- a/autoload/neoterm.vim
+++ b/autoload/neoterm.vim
@@ -11,9 +11,9 @@ function! neoterm#exec(list)
   if !exists('g:neoterm_current_id')
     let current_window = winnr()
     if g:neoterm_position == 'horizontal'
-      let split_cmd = "botright ".g:neoterm_size."new | term"
+      let split_cmd = "botright ".g:neoterm_size."new | term $SHELL"
     else
-      let split_cmd = "botright vert ".g:neoterm_size."new | term"
+      let split_cmd = "botright vert ".g:neoterm_size."new | term $SHELL"
     end
 
     exec split_cmd | exec current_window . "wincmd w | set noim"


### PR DESCRIPTION
I personally run zsh and was wanting neoterm commands to run using zsh when executing them instead of sh. This PR should mean term commands run using the user's shell rather than the system default.

Happy for any feedback you have.