### PR TITLE
Auto reopen neoterm buffer.

### DIFF
--- a/autoload/neoterm.vim
+++ b/autoload/neoterm.vim
@@ -8,12 +8,21 @@ endfunction
 
 " Loads a terminal, if it is not loaded, and execute a list of commands.
 function! neoterm#exec(list)
+  let current_window = winnr()
+
   if !exists('g:neoterm_current_id')
-    let current_window = winnr()
     if g:neoterm_position == 'horizontal'
       let split_cmd = "botright ".g:neoterm_size."new | term"
     else
       let split_cmd = "botright vert ".g:neoterm_size."new | term"
+    end
+
+    exec split_cmd | exec current_window . "wincmd w | set noim"
+  elseif exists('g:neoterm_buffer_id') && bufwinnr(g:neoterm_buffer_id) == -1
+    if g:neoterm_position == 'horizontal'
+      let split_cmd = "botright ".g:neoterm_size." sbuffer ".g:neoterm_buffer_id
+    else
+      let split_cmd = "botright vert ".g:neoterm_size."sbuffer ".g:neoterm_buffer_id
     end
 
     exec split_cmd | exec current_window . "wincmd w | set noim"

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -22,6 +22,7 @@ end
 
 aug neoterm_setup
   au TermOpen * let g:neoterm_current_id = b:terminal_job_id
+  au TermOpen * let g:neoterm_buffer_id = bufnr('%')
   au TermOpen * setlocal nonumber norelativenumber
   au BufUnload term://*
         \ if exists('g:neoterm_current_id') |


### PR DESCRIPTION
> When the buffer window was closed an new neoterm commands is executed the
> command is issued in the background.
>
> I see no reason why neoterm should not create a new window with the correct term
> buffer on consecutive calls if now current neoterm window is visible.

Please let me know if you want me to make this configurable or if you want me change something else before you can merge it.





