### PR TITLE
Don't attempt to load if not in neovim

### DIFF
--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -1,3 +1,7 @@
+if !has("nvim")
+    finish
+endif
+
 let g:neoterm_last_test_command = ''
 
 if !exists('g:neoterm_size')


### PR DESCRIPTION
Added a quick guard to avoid attempting to load if we are in regular vim