### PR TITLE
Using terminal callbacks to put on statusline the test status.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ REPL commands, opens a terminal and the proper REPL, if it's not opened.
 
 - NeoVim terminal helper functions/commands.
 - Wraps some test libs to run easilly within NeoVim terminal.
+  - Running, Success, Failed: status on statusline supported (matching the test
+    result #25):
+    ![test-status-line](https://cloud.githubusercontent.com/assets/120483/8212291/425189d2-14f1-11e5-8059-822eda0b702c.gif)
 - Wraps some REPL to receive current line or selection.
 
 ## test libs
@@ -33,10 +36,12 @@ it's the command: `rspec spec/path/to/file_spec.rb:123`.
 * rspec
   * You can override the default command (`bundle exec rspec`) using the
     `g:neoterm_rspec_lib_cmd`
+  * Status in statusline supported
 * cucumber
   * You can override the default command (`bundle exec cucumber`) using the
     `g:neoterm_cucumber_lib_cmd`
 * minitest
+  * Status in statusline supported
 * go-lang test ([partially implemented](https://github.com/kassio/neoterm/pull/8))
 * nose ([partially implemented](https://github.com/kassio/neoterm/pull/9))
 

--- a/a.vim
+++ b/a.vim
@@ -1,0 +1,49 @@
+set confirm
+let Shell = {}
+
+function Shell.on_stdout(job_id, data)
+  call append(line('$'), 'OUT: '.join(a:data))
+endfunction
+
+function Shell.on_stderr(job_id, data)
+  call append(line('$'), 'ERR: '.join(a:data))
+endfunction
+
+function Shell.on_exit(job_id, data)
+  call append(line('$'), 'exited: '.a:data)
+endfunction
+
+function Shell.get_name()
+  return 'shell '.self.name
+endfunction
+
+function Shell.new(name, ...)
+  let instance = extend(copy(g:Shell), {'name': a:name})
+  let argv = ['bash']
+  if a:0 > 0
+    let argv += ['-c', a:1]
+  endif
+  new
+  let instance.id = jobstart(argv, instance)
+  return instance
+endfunction
+
+function! BufDo(command)
+  let currBuff=bufnr("%")
+  execute 'bufdo ' . a:command
+  execute 'buffer ' . currBuff
+endfunction
+
+let s1 = Shell.new('1', 'rake')
+" let s2 = Shell.new('2', 'for i in {1..10}; do a; echo hello $i!; done')
+"
+" function! s:JobHandler(job_id, data, event)
+"   echom a:event.': '.string(a:data)
+" endfunction
+" let s:callbacks = {
+"       \ 'on_stdout': function('s:JobHandler'),
+"       \ 'on_stderr': function('s:JobHandler')
+"       \ }
+"
+" new | call termopen([&sh, &shcf, 'echo "STDOUT"'], s:callbacks)
+" new | call termopen([&sh, &shcf, 'BOOM'], s:callbacks)

--- a/autoload/neoterm.vim
+++ b/autoload/neoterm.vim
@@ -1,9 +1,9 @@
 " Internal: Loads a terminal, if it is not loaded, and execute a list of
 " commands.
-function! neoterm#exec(list, ...)
+function! neoterm#exec(list)
   let current_window = winnr()
 
-  call neoterm#open(get(a:, '1', {}))
+  call neoterm#open()
   call jobsend(g:neoterm_terminal_jid, a:list)
 
   if g:neoterm_keep_term_open
@@ -15,15 +15,18 @@ function! neoterm#exec(list, ...)
 endfunction
 
 " Internal: Creates a new neoterm buffer, or opens if it already exists.
-function! neoterm#open(...)
-  return neoterm#show() || neoterm#new(get(a:, '1', {}))
+function! neoterm#open()
+  return neoterm#show() || neoterm#new()
 endfunction
 
 " Internal: Creates a new neoterm buffer if there is no one.
 "
 " Returns: 1 if a new terminal was created, 0 otherwise.
-function! neoterm#new(opts)
-  let opts = extend({ 'name': 'NEOTERM' }, a:opts)
+function! neoterm#new()
+  let opts = extend(
+        \ { 'name': 'NEOTERM' },
+        \ neoterm#test#handlers()
+        \ )
 
   if !exists('g:neoterm_terminal_jid') " there is no neoterm running
     exec <sid>split_cmd()

--- a/autoload/neoterm.vim
+++ b/autoload/neoterm.vim
@@ -16,14 +16,34 @@ endfunction
 
 " Internal: Creates a new neoterm buffer, or opens if it already exists.
 function! neoterm#open(...)
-  let opts = extend({ 'name': 'NEOTERM' }, get(a:, '1', {}))
+  return neoterm#show() || neoterm#new(get(a:, '1', {}))
+endfunction
+
+" Internal: Creates a new neoterm buffer if there is no one.
+"
+" Returns: 1 if a new terminal was created, 0 otherwise.
+function! neoterm#new(opts)
+  let opts = extend({ 'name': 'NEOTERM' }, a:opts)
 
   if !exists('g:neoterm_terminal_jid') " there is no neoterm running
     exec <sid>split_cmd()
     call termopen([&sh], opts)
-  elseif !neoterm#tab_has_neoterm() " neoturm is running but not on current tab
+    return 1
+  else
+    return 0
+  end
+endfunction
+
+" Internal: Open a new split with the current neoterm buffer if there is one.
+"
+" Returns: 1 if a neoterm split is opened, 0 otherwise.
+function! neoterm#show()
+  if exists('g:neoterm_terminal_jid') && !neoterm#tab_has_neoterm()
     exec <sid>split_cmd()
     exec "buffer ".g:neoterm_buffer_id
+    return 1
+  else
+    return 0
   end
 endfunction
 

--- a/autoload/neoterm.vim
+++ b/autoload/neoterm.vim
@@ -21,7 +21,7 @@ function! neoterm#open(...)
   if !exists('g:neoterm_terminal_jid') " there is no neoterm running
     exec <sid>split_cmd()
     call termopen([&sh], opts)
-  elseif !<sid>tab_has_neoterm() " neoturm is running but not on current tab
+  elseif !neoterm#tab_has_neoterm() " neoturm is running but not on current tab
     exec <sid>split_cmd()
     exec "buffer ".g:neoterm_buffer_id
   end
@@ -36,7 +36,7 @@ function! s:split_cmd()
 endfunction
 
 " Internal: Verifies if neoterm is open for current tab.
-function! s:tab_has_neoterm()
+function! neoterm#tab_has_neoterm()
   return exists('g:neoterm_buffer_id') &&
         \ bufexists(g:neoterm_buffer_id) > 0 &&
         \ bufwinnr(g:neoterm_buffer_id) != -1

--- a/autoload/neoterm.vim
+++ b/autoload/neoterm.vim
@@ -21,7 +21,7 @@ function! neoterm#open(...)
   if !exists('g:neoterm_terminal_jid') " there is no neoterm running
     exec <sid>split_cmd()
     call termopen([&sh], opts)
-  elseif !<sid>tab_has_neoterm() " there is no neoterm on current tab
+  elseif !<sid>tab_has_neoterm() " neoturm is running but not on current tab
     exec <sid>split_cmd()
     exec "buffer ".g:neoterm_buffer_id
   end
@@ -61,13 +61,13 @@ function! neoterm#close_all()
 
   for b in all_buffers
     if bufname(b) =~ "term:\/\/.*NEOTERM"
-      call <sid>close_term_buffer(b)
+      call neoterm#close_buffer(b)
     end
   endfor
 endfunction
 
 " Internal: Closes/Hides a given buffer.
-function! s:close_term_buffer(buffer)
+function! neoterm#close_buffer(buffer)
   if g:neoterm_keep_term_open
     if bufwinnr(a:buffer) > 0 " check if the buffer is visible
       exec bufwinnr(a:buffer) . "hide"

--- a/autoload/neoterm/test.vim
+++ b/autoload/neoterm/test.vim
@@ -15,7 +15,7 @@ endfunction
 
 function! s:run(command)
   let should_hide = !neoterm#tab_has_neoterm()
-  let g:neoterm_statusline = 'RUNNING'
+  let g:neoterm_statusline = g:neoterm_test_status.running
 
   call neoterm#exec(
         \ [g:neoterm_clear_cmd, a:command, ''],
@@ -47,7 +47,9 @@ endfunction
 
 function! s:test_result(job_id, data, event)
   if a:event == 'exit'
-    let g:neoterm_statusline = a:data == '0' ? 'SUCCESS' : 'FAILED'
+    let g:neoterm_statusline = a:data == '0' ?
+          \ g:neoterm_test_status.success :
+          \ g:neoterm_test_status.failed
   else
     let Fn = function('neoterm#test#' . g:neoterm_test_lib . '#result')
     for line in a:data
@@ -58,19 +60,20 @@ function! s:test_result(job_id, data, event)
   call <sid>raise_term_buffer()
 endfunction
 
-function! neoterm#test#statusline(...)
-  let result = !empty(a:000) ? a:1 : ''
-
+function! neoterm#test#status(status)
   redrawstatus!
-  if g:neoterm_statusline =~? result
-    return '['.g:neoterm_statusline.']'
+
+  if g:neoterm_statusline == g:neoterm_test_status[a:status]
+    return printf(g:neoterm_test_status_format, g:neoterm_statusline)
   else
     return ''
   end
 endfunction
 
 function! s:raise_term_buffer()
-  if g:neoterm_statusline == 'FAILED' && g:neoterm_raise_when_tests_fail
+  if g:neoterm_statusline == g:neoterm_test_status.failed
+        \ && g:neoterm_raise_when_tests_fail
+
     let current_window = winnr()
     call neoterm#open()
     silent exec current_window . "wincmd w | set noinsertmode"

--- a/autoload/neoterm/test.vim
+++ b/autoload/neoterm/test.vim
@@ -54,6 +54,8 @@ function! s:test_result(job_id, data, event)
       call Fn(line)
     endfor
   end
+
+  call <sid>raise_term_buffer()
 endfunction
 
 function! neoterm#test#statusline(...)
@@ -64,5 +66,13 @@ function! neoterm#test#statusline(...)
     return '['.g:neoterm_statusline.']'
   else
     return ''
+  end
+endfunction
+
+function! s:raise_term_buffer()
+  if g:neoterm_statusline == 'FAILED' && g:neoterm_raise_when_tests_fail
+    let current_window = winnr()
+    call neoterm#open()
+    silent exec current_window . "wincmd w | set noinsertmode"
   end
 endfunction

--- a/autoload/neoterm/test.vim
+++ b/autoload/neoterm/test.vim
@@ -45,7 +45,9 @@ function! s:test_result(job_id, data, event)
     let g:neoterm_statusline = a:data == '0' ? 'SUCCESS' : 'FAILED'
   else
     let Fn = function('neoterm#test#' . g:neoterm_test_lib . '#result')
-    call Fn(a:data[0])
+    for line in a:data
+      call Fn(line)
+    endfor
   end
 endfunction
 

--- a/autoload/neoterm/test.vim
+++ b/autoload/neoterm/test.vim
@@ -41,14 +41,15 @@ endfunction
 " Internal: Builds the dictionary with all test event handlers.
 function! neoterm#test#handlers()
   return  {
-        \   'on_stdout': function('s:test_result'),
-        \   'on_stderr': function('s:test_result'),
-        \   'on_exit': function('s:test_result')
+        \   'on_stdout': function('s:test_result_handler'),
+        \   'on_stderr': function('s:test_result_handler'),
+        \   'on_exit': function('s:test_result_handler')
         \ }
 endfunction
 
-" TODO: doc
-function! s:test_result(job_id, data, event)
+" Internal: Handle the test results using the current test library test
+" result's handler.
+function! s:test_result_handler(job_id, data, event)
   " Only change statusline if tests were running
   if g:neoterm_statusline != g:neoterm_test_status.running
     return
@@ -60,7 +61,7 @@ function! s:test_result(job_id, data, event)
           \ g:neoterm_test_status.failed
   else
     try
-      let Fn = function('neoterm#test#' . g:neoterm_test_lib . '#result')
+      let Fn = function('neoterm#test#' . g:neoterm_test_lib . '#result_handler')
       for line in a:data
         call Fn(line)
       endfor

--- a/autoload/neoterm/test.vim
+++ b/autoload/neoterm/test.vim
@@ -17,14 +17,7 @@ function! s:run(command)
   let should_hide = !neoterm#tab_has_neoterm() && g:neoterm_run_tests_bg
   let g:neoterm_statusline = g:neoterm_test_status.running
 
-  call neoterm#exec(
-        \ [g:neoterm_clear_cmd, a:command, ''],
-        \   {
-        \     'on_stdout': function('s:test_result'),
-        \     'on_stderr': function('s:test_result'),
-        \     'on_exit': function('s:test_result')
-        \   }
-        \ )
+  call neoterm#exec(["\<c-l>", a:command, ''])
 
   if should_hide
     call neoterm#close_buffer(g:neoterm_buffer_id)
@@ -43,6 +36,15 @@ function! s:get_test_command(scope)
   end
 
   return Fn(a:scope)
+endfunction
+
+" Internal: Builds the dictionary with all test event handlers.
+function! neoterm#test#handlers()
+  return  {
+        \   'on_stdout': function('s:test_result'),
+        \   'on_stderr': function('s:test_result'),
+        \   'on_exit': function('s:test_result')
+        \ }
 endfunction
 
 function! s:test_result(job_id, data, event)

--- a/autoload/neoterm/test.vim
+++ b/autoload/neoterm/test.vim
@@ -14,6 +14,7 @@ function! neoterm#test#rerun()
 endfunction
 
 function! s:run(command)
+  let should_hide = !neoterm#tab_has_neoterm()
   let g:neoterm_statusline = 'RUNNING'
 
   call neoterm#exec(
@@ -24,6 +25,10 @@ function! s:run(command)
         \     'on_exit': function('s:test_result')
         \   }
         \ )
+
+  if should_hide
+    call neoterm#close_buffer(g:neoterm_buffer_id)
+  end
 endfunction
 
 " Internal: Get the command with the current test lib.

--- a/autoload/neoterm/test.vim
+++ b/autoload/neoterm/test.vim
@@ -47,7 +47,13 @@ function! neoterm#test#handlers()
         \ }
 endfunction
 
+" TODO: doc
 function! s:test_result(job_id, data, event)
+  " Only change statusline if tests were running
+  if g:neoterm_statusline != g:neoterm_test_status.running
+    return
+  end
+
   if a:event == 'exit'
     let g:neoterm_statusline = a:data == '0' ?
           \ g:neoterm_test_status.success :

--- a/autoload/neoterm/test.vim
+++ b/autoload/neoterm/test.vim
@@ -1,15 +1,37 @@
 " Public: Runs the current test lib with the given scope.
 function! neoterm#test#run(scope)
   let g:neoterm_last_test_command = <sid>get_test_command(a:scope)
+  " silent call neoterm#exec([g:neoterm_clear_cmd, g:neoterm_last_test_command, ''])
 
-  echo g:neoterm_last_test_command
-  silent call neoterm#exec([g:neoterm_clear_cmd, g:neoterm_last_test_command, ''])
+  new
+  call termopen(
+        \   [&sh, &shcf, g:neoterm_last_test_command],
+        \   {
+        \     'name': 'NEOTERM-TEST',
+        \     'on_stdout': function('s:test_result'),
+        \     'on_stderr': function('s:test_result'),
+        \     'on_exit': function('s:test_result')
+        \   }
+        \ )
+  let g:neoterm_statusline = 'RUNNING'
 endfunction
 
 " Public: Re-run the last test command.
 function! neoterm#test#rerun()
   if exists('g:neoterm_last_test_command')
-    silent call neoterm#exec([g:neoterm_last_test_command, ''])
+    "silent call neoterm#exec([g:neoterm_last_test_command, ''])
+
+    new
+    call termopen(
+          \   [&sh, &shcf, g:neoterm_last_test_command],
+          \   {
+          \     'name': 'NEOTERM-TEST',
+          \     'on_stdout': function('s:test_result'),
+          \     'on_stderr': function('s:test_result'),
+          \     'on_exit': function('s:test_result')
+          \   }
+          \ )
+    let g:neoterm_statusline = 'RUNNING'
   else
     echo 'No test has been runned.'
   endif
@@ -27,4 +49,23 @@ function! s:get_test_command(scope)
   end
 
   return Fn(a:scope)
+endfunction
+
+function! s:test_result(job_id, data, event)
+  if a:event == 'exit'
+    let g:neoterm_statusline = a:data == '0' ? 'SUCCESS' : 'FAILED'
+  else
+    let Fn = function('neoterm#test#' . g:neoterm_test_lib . '#result')
+    call Fn(a:data[0])
+  end
+endfunction
+
+function! neoterm#test#statusline(...)
+  let result = !empty(a:000) ? a:1 : ''
+
+  if g:neoterm_statusline =~? result
+    return '['.g:neoterm_statusline.']'
+  else
+    return ''
+  end
 endfunction

--- a/autoload/neoterm/test.vim
+++ b/autoload/neoterm/test.vim
@@ -54,6 +54,7 @@ endfunction
 function! neoterm#test#statusline(...)
   let result = !empty(a:000) ? a:1 : ''
 
+  redrawstatus!
   if g:neoterm_statusline =~? result
     return '['.g:neoterm_statusline.']'
   else

--- a/autoload/neoterm/test.vim
+++ b/autoload/neoterm/test.vim
@@ -14,7 +14,7 @@ function! neoterm#test#rerun()
 endfunction
 
 function! s:run(command)
-  let should_hide = !neoterm#tab_has_neoterm()
+  let should_hide = !neoterm#tab_has_neoterm() && g:neoterm_run_tests_bg
   let g:neoterm_statusline = g:neoterm_test_status.running
 
   call neoterm#exec(

--- a/autoload/neoterm/test.vim
+++ b/autoload/neoterm/test.vim
@@ -51,10 +51,14 @@ function! s:test_result(job_id, data, event)
           \ g:neoterm_test_status.success :
           \ g:neoterm_test_status.failed
   else
-    let Fn = function('neoterm#test#' . g:neoterm_test_lib . '#result')
-    for line in a:data
-      call Fn(line)
-    endfor
+    try
+      let Fn = function('neoterm#test#' . g:neoterm_test_lib . '#result')
+      for line in a:data
+        call Fn(line)
+      endfor
+    catch 'E117'
+      return
+    endtry
   end
 
   call <sid>raise_term_buffer()

--- a/autoload/neoterm/test.vim
+++ b/autoload/neoterm/test.vim
@@ -75,7 +75,7 @@ function! s:raise_term_buffer()
         \ && g:neoterm_raise_when_tests_fail
 
     let current_window = winnr()
-    call neoterm#open()
+    call neoterm#show()
     silent exec current_window . "wincmd w | set noinsertmode"
   end
 endfunction

--- a/autoload/neoterm/test.vim
+++ b/autoload/neoterm/test.vim
@@ -1,40 +1,29 @@
 " Public: Runs the current test lib with the given scope.
 function! neoterm#test#run(scope)
   let g:neoterm_last_test_command = <sid>get_test_command(a:scope)
-  " silent call neoterm#exec([g:neoterm_clear_cmd, g:neoterm_last_test_command, ''])
-
-  new
-  call termopen(
-        \   [&sh, &shcf, g:neoterm_last_test_command],
-        \   {
-        \     'name': 'NEOTERM-TEST',
-        \     'on_stdout': function('s:test_result'),
-        \     'on_stderr': function('s:test_result'),
-        \     'on_exit': function('s:test_result')
-        \   }
-        \ )
-  let g:neoterm_statusline = 'RUNNING'
+  call <sid>run(g:neoterm_last_test_command)
 endfunction
 
 " Public: Re-run the last test command.
 function! neoterm#test#rerun()
   if exists('g:neoterm_last_test_command')
-    "silent call neoterm#exec([g:neoterm_last_test_command, ''])
-
-    new
-    call termopen(
-          \   [&sh, &shcf, g:neoterm_last_test_command],
-          \   {
-          \     'name': 'NEOTERM-TEST',
-          \     'on_stdout': function('s:test_result'),
-          \     'on_stderr': function('s:test_result'),
-          \     'on_exit': function('s:test_result')
-          \   }
-          \ )
-    let g:neoterm_statusline = 'RUNNING'
+    call <sid>run(g:neoterm_last_test_command)
   else
     echo 'No test has been runned.'
   endif
+endfunction
+
+function! s:run(command)
+  let g:neoterm_statusline = 'RUNNING'
+
+  call neoterm#exec(
+        \ [g:neoterm_clear_cmd, a:command, ''],
+        \   {
+        \     'on_stdout': function('s:test_result'),
+        \     'on_stderr': function('s:test_result'),
+        \     'on_exit': function('s:test_result')
+        \   }
+        \ )
 endfunction
 
 " Internal: Get the command with the current test lib.

--- a/autoload/neoterm/test/minitest.vim
+++ b/autoload/neoterm/test/minitest.vim
@@ -27,27 +27,20 @@ function! s:minitest_get_current()
   endif
 endfunction
 
-" 8 runs, 11 assertions, 1 failure, no errors, no skips
-" 8 runs, 11 assertions, no failures, no errors, no skips
 function! neoterm#test#minitest#result(line)
   let counters = matchlist(
         \ a:line,
-        \ '\(\d\+\|no\) failures\?, \(\d\+\|no\) errors\?, \(\d\+\|no\) skips\?'
+        \ '\(\d\+\|no\) failures\?, \(\d\+\|no\) errors\?'
         \ )
 
   if !empty(counters)
     let failures = counters[1]
     let errors = counters[2]
-    let skips = counters[3]
 
     if failures == 'no' && errors == 'no'
       let g:neoterm_statusline = 'SUCCESS'
     else
       let g:neoterm_statusline = 'FAILED'
-    end
-
-    if skips != 'no'
-      let g:neoterm_statusline .= '*'
     end
   end
 endfunction

--- a/autoload/neoterm/test/minitest.vim
+++ b/autoload/neoterm/test/minitest.vim
@@ -37,7 +37,7 @@ function! neoterm#test#minitest#result(line)
     let failures = counters[1]
     let errors = counters[2]
 
-    if failures == 'no' && errors == 'no'
+    if str2nr(failures) == 0 && str2nr(errors) == 0
       let g:neoterm_statusline = 'SUCCESS'
     else
       let g:neoterm_statusline = 'FAILED'

--- a/autoload/neoterm/test/minitest.vim
+++ b/autoload/neoterm/test/minitest.vim
@@ -38,9 +38,9 @@ function! neoterm#test#minitest#result(line)
     let errors = counters[2]
 
     if str2nr(failures) == 0 && str2nr(errors) == 0
-      let g:neoterm_statusline = 'SUCCESS'
+      let g:neoterm_statusline = g:neoterm_test_status.success
     else
-      let g:neoterm_statusline = 'FAILED'
+      let g:neoterm_statusline = g:neoterm_test_status.failed
     end
   end
 endfunction

--- a/autoload/neoterm/test/minitest.vim
+++ b/autoload/neoterm/test/minitest.vim
@@ -27,7 +27,7 @@ function! s:minitest_get_current()
   endif
 endfunction
 
-function! neoterm#test#minitest#result(line)
+function! neoterm#test#minitest#result_handler(line)
   let counters = matchlist(
         \ a:line,
         \ '\(\d\+\|no\) failures\?, \(\d\+\|no\) errors\?'

--- a/autoload/neoterm/test/minitest.vim
+++ b/autoload/neoterm/test/minitest.vim
@@ -26,3 +26,28 @@ function! s:minitest_get_current()
     endif
   endif
 endfunction
+
+" 8 runs, 11 assertions, 1 failure, no errors, no skips
+" 8 runs, 11 assertions, no failures, no errors, no skips
+function! neoterm#test#minitest#result(line)
+  let counters = matchlist(
+        \ a:line,
+        \ '\(\d\+\|no\) failures\?, \(\d\+\|no\) errors\?, \(\d\+\|no\) skips\?'
+        \ )
+
+  if !empty(counters)
+    let failures = counters[1]
+    let errors = counters[2]
+    let skips = counters[3]
+
+    if failures == 'no' && errors == 'no'
+      let g:neoterm_statusline = 'SUCCESS'
+    else
+      let g:neoterm_statusline = 'FAILED'
+    end
+
+    if skips != 'no'
+      let g:neoterm_statusline .= '*'
+    end
+  end
+endfunction

--- a/autoload/neoterm/test/rspec.vim
+++ b/autoload/neoterm/test/rspec.vim
@@ -13,3 +13,20 @@ function! neoterm#test#rspec#run(scope)
 
   return command
 endfunction
+
+function! neoterm#test#rspec#result(line)
+  let counters = matchlist(
+        \ a:line,
+        \ '\(\d\+\|no\) failures\?'
+        \ )
+
+  if !empty(counters)
+    let failures = counters[1]
+
+    if str2nr(failures) == 0
+      let g:neoterm_statusline = g:neoterm_test_status.success
+    else
+      let g:neoterm_statusline = g:neoterm_test_status.failed
+    end
+  end
+endfunction

--- a/autoload/neoterm/test/rspec.vim
+++ b/autoload/neoterm/test/rspec.vim
@@ -14,7 +14,7 @@ function! neoterm#test#rspec#run(scope)
   return command
 endfunction
 
-function! neoterm#test#rspec#result(line)
+function! neoterm#test#rspec#result_handler(line)
   let counters = matchlist(
         \ a:line,
         \ '\(\d\+\|no\) failures\?'

--- a/doc/neoterm.txt
+++ b/doc/neoterm.txt
@@ -56,6 +56,11 @@ but it can be changed in |g:neoterm_position|
 Chooses, or changes, the current test lib.
 
 
+:TTestClearStatus                                            *:TTestClearStatus*
+
+Clear the test result status on statusline.
+
+
 :TREPLSend                                                          *:TREPLSend*
 
 Sends the current selection, or current line, to a REPL.
@@ -113,8 +118,27 @@ Key combination to be used with |:Tmap|.
 Default value: `,tt`.
                                                       *g:neoterm_keep_term_open*
 
-Set it a neoterm terminal will be kept running in background.
+When set, neoterm terminal will be kept running in background.
 Default value: `1`.
 
+                                                        *g:neoterm_run_tests_bg*
+
+When set, the neoterm will not open the term split to run tests.
+Default value: `0`.
+
+                                               *g:neoterm_raise_when_tests_fail*
+
+When set, the neoterm open the term split if the tests broken.
+Default value: `0`.
+
+                                                  *g:neoterm_test_status_format*
+
+This string will be used to format the string used in the statusline.
+Default value: `[%s]`.
+
+                                                         *g:neoterm_test_status*
+
+Defines the strings/symbols/emojis used in each test status.
+Default value: `{` `'running'``:` `'RUNNING'``,` `'success'``:` `'SUCCESS'``,` `'failed'``:` `'FAILED'` `}`
 
 vim: fo= ts=8 sw=8 noet nosta nosr ft=help

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -29,6 +29,10 @@ if !exists('g:neoterm_run_tests_bg')
   let g:neoterm_run_tests_bg = 0
 end
 
+if !exists('g:neoterm_raise_when_tests_fail')
+  let g:neoterm_raise_when_tests_fail = 0
+end
+
 hi! NeotermTestRunning ctermfg=11 ctermbg=0
 hi! NeotermTestSuccess ctermfg=2 ctermbg=0
 hi! NeotermTestFailure ctermfg=1 ctermbg=0

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -25,22 +25,18 @@ if !exists('g:neoterm_keep_term_open')
   let g:neoterm_keep_term_open = 1
 end
 
-" TODO: doc
 if !exists('g:neoterm_run_tests_bg')
   let g:neoterm_run_tests_bg = 0
 end
 
-" TODO: doc
 if !exists('g:neoterm_raise_when_tests_fail')
   let g:neoterm_raise_when_tests_fail = 0
 end
 
-" TODO: doc
 if !exists('g:neoterm_test_status_format')
   let g:neoterm_test_status_format = '[%s]'
 end
 
-" TODO: doc
 if !exists('g:neoterm_test_status')
   let g:neoterm_test_status = {
         \ 'running': 'RUNNING',
@@ -66,7 +62,6 @@ aug END
 command! -range=% TREPLSendFile call neoterm#repl#selection(<line1>, <line2>)
 command! -range TREPLSend call neoterm#repl#selection(<line1>, <line2>)
 command! -complete=customlist,neoterm#test#libs#autocomplete -nargs=? TTestLib call neoterm#test#libs#add(<q-args>)
-" TODO: doc
 command! TTestClearStatus let g:neoterm_statusline=''
 command! -nargs=1 Tpos let g:neoterm_position=<q-args>
 

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -3,6 +3,7 @@ if !has("nvim")
 endif
 
 let g:neoterm_last_test_command = ''
+let g:neoterm_statusline = ''
 
 if !exists('g:neoterm_size')
   let g:neoterm_size = ''
@@ -23,8 +24,6 @@ end
 if !exists('g:neoterm_keep_term_open')
   let g:neoterm_keep_term_open = 1
 end
-
-let g:neoterm_statusline = ''
 
 hi! NeotermTestRunning ctermfg=11 ctermbg=0
 hi! NeotermTestSuccess ctermfg=2 ctermbg=0

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -62,6 +62,7 @@ aug END
 command! -range=% TREPLSendFile call neoterm#repl#selection(<line1>, <line2>)
 command! -range TREPLSend call neoterm#repl#selection(<line1>, <line2>)
 command! -complete=customlist,neoterm#test#libs#autocomplete -nargs=? TTestLib call neoterm#test#libs#add(<q-args>)
+command! TTestClearStatus let g:neoterm_statusline=''
 command! -nargs=1 Tpos let g:neoterm_position=<q-args>
 
 command! -complete=shellcmd Topen call neoterm#open()

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -25,6 +25,10 @@ if !exists('g:neoterm_keep_term_open')
   let g:neoterm_keep_term_open = 1
 end
 
+if !exists('g:neoterm_run_tests_bg')
+  let g:neoterm_run_tests_bg = 0
+end
+
 hi! NeotermTestRunning ctermfg=11 ctermbg=0
 hi! NeotermTestSuccess ctermfg=2 ctermbg=0
 hi! NeotermTestFailure ctermfg=1 ctermbg=0

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -25,18 +25,22 @@ if !exists('g:neoterm_keep_term_open')
   let g:neoterm_keep_term_open = 1
 end
 
+" TODO: doc
 if !exists('g:neoterm_run_tests_bg')
   let g:neoterm_run_tests_bg = 0
 end
 
+" TODO: doc
 if !exists('g:neoterm_raise_when_tests_fail')
   let g:neoterm_raise_when_tests_fail = 0
 end
 
+" TODO: doc
 if !exists('g:neoterm_test_status_format')
   let g:neoterm_test_status_format = '[%s]'
 end
 
+" TODO: doc
 if !exists('g:neoterm_test_status')
   let g:neoterm_test_status = {
         \ 'running': 'RUNNING',
@@ -62,6 +66,7 @@ aug END
 command! -range=% TREPLSendFile call neoterm#repl#selection(<line1>, <line2>)
 command! -range TREPLSend call neoterm#repl#selection(<line1>, <line2>)
 command! -complete=customlist,neoterm#test#libs#autocomplete -nargs=? TTestLib call neoterm#test#libs#add(<q-args>)
+" TODO: doc
 command! TTestClearStatus let g:neoterm_statusline=''
 command! -nargs=1 Tpos let g:neoterm_position=<q-args>
 

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -24,6 +24,12 @@ if !exists('g:neoterm_keep_term_open')
   let g:neoterm_keep_term_open = 1
 end
 
+let g:neoterm_statusline = ''
+
+hi! NeotermTestRunning ctermfg=11 ctermbg=0
+hi! NeotermTestSuccess ctermfg=2 ctermbg=0
+hi! NeotermTestFailure ctermfg=1 ctermbg=0
+
 aug neoterm_setup
   au TermOpen *NEOTERM let g:neoterm_terminal_jid = b:terminal_job_id
   au TermOpen *NEOTERM let g:neoterm_buffer_id = bufnr('%')

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -33,6 +33,18 @@ if !exists('g:neoterm_raise_when_tests_fail')
   let g:neoterm_raise_when_tests_fail = 0
 end
 
+if !exists('g:neoterm_test_status_format')
+  let g:neoterm_test_status_format = '[%s]'
+end
+
+if !exists('g:neoterm_test_status')
+  let g:neoterm_test_status = {
+        \ 'running': 'RUNNING',
+        \ 'success': 'SUCCESS',
+        \ 'failed': 'FAILED'
+        \ }
+end
+
 hi! NeotermTestRunning ctermfg=11 ctermbg=0
 hi! NeotermTestSuccess ctermfg=2 ctermbg=0
 hi! NeotermTestFailure ctermfg=1 ctermbg=0

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -50,9 +50,9 @@ hi! NeotermTestSuccess ctermfg=2 ctermbg=0
 hi! NeotermTestFailure ctermfg=1 ctermbg=0
 
 aug neoterm_setup
-  au TermOpen *NEOTERM let g:neoterm_terminal_jid = b:terminal_job_id
-  au TermOpen *NEOTERM let g:neoterm_buffer_id = bufnr('%')
-  au TermOpen *NEOTERM setlocal nonumber norelativenumber
+  au TermOpen term://*:NEOTERM let g:neoterm_terminal_jid = b:terminal_job_id
+  au TermOpen term://*:NEOTERM let g:neoterm_buffer_id = bufnr('%')
+  au TermOpen term://*:NEOTERM setlocal nonumber norelativenumber
   au BufUnload,BufDelete,BufWipeout term://*:NEOTERM
         \ unlet! g:neoterm_terminal_jid |
         \ unlet! g:neoterm_buffer_id |


### PR DESCRIPTION
Using terminal callbacks, now it's possible to parse the test output and analyses whether the test passed or not.
To get a clear feedback neoterm is using 3 possible states for a test: 'RUNNING', 'SUCCESS', 'FAILED', for each one we have a new highlight group to be used in the statusline.

related with #24

**TODO**
- [x] Use `neoterm#exec()`
- [x] Add an option to run tests without open the terminal split
- [x] Add an option to auto-open terminal split when tests break
- [x] Add option to chose text/symbols to each test state
![neoterm-test-status-emoji](https://cloud.githubusercontent.com/assets/120483/8212291/425189d2-14f1-11e5-8059-822eda0b702c.gif)
- [x] Add documentation

related with #24
![neoterm-test-status](https://cloud.githubusercontent.com/assets/120483/8208637/09d2ec8e-14df-11e5-92ec-a7d6c28aa821.gif)
