### PR TITLE
support shell override

### DIFF
--- a/autoload/neoterm.vim
+++ b/autoload/neoterm.vim
@@ -30,7 +30,7 @@ function! neoterm#new()
 
   if !exists('g:neoterm_terminal_jid') " there is no neoterm running
     exec <sid>split_cmd()
-    call termopen([&sh], opts)
+    call termopen([g:neoterm_shell], opts)
     return 1
   else
     return 0

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -5,6 +5,10 @@ endif
 let g:neoterm_last_test_command = ''
 let g:neoterm_statusline = ''
 
+if !exists('g:neoterm_shell')
+  let g:neoterm_shell = &sh
+end
+
 if !exists('g:neoterm_size')
   let g:neoterm_size = ''
 end


### PR DESCRIPTION
Allow overriding the vim specific `shell` using `g:neoterm_shell`, for example:-

**~/.nvimrc**:
```vim
...
set shell=sh
set g:neoterm_shell=bash
...
```
