### PR TITLE
Introduce multiple terms management.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ REPL commands, opens a terminal and the proper REPL, if it's not opened.
 
 - NeoVim terminal helper functions/commands.
 - Wraps some test libs to run easilly within NeoVim terminal.
-  - Running, Success, Failed: status on statusline supported (matching the test
-    result #25):
+  - Running, Success, Failed: status on statusline supported (matching the test result #25):
     ![test-status-line](https://cloud.githubusercontent.com/assets/120483/8212291/425189d2-14f1-11e5-8059-822eda0b702c.gif)
 - Wraps some REPL to receive current line or selection.
+- Many terminals support
+  ![many-terms](https://cloud.githubusercontent.com/assets/120483/8921869/fe459572-34b1-11e5-93c9-c3b6f3b44719.gif)
 
 ## test libs
 

--- a/autoload/neoterm.term.vim
+++ b/autoload/neoterm.term.vim
@@ -1,0 +1,96 @@
+let g:neoterm.term = {}
+
+function! g:neoterm.term.new(id, handlers)
+  let name = ";#neoterm-".a:id
+  let instance = extend(copy(self), {
+        \ "id": a:id,
+        \ })
+
+  let instance.handlers = a:handlers
+
+  let instance.job_id = termopen(g:neoterm_shell . name, instance)
+  let instance.buffer_id = bufnr("")
+
+  return instance
+endfunction
+
+function! g:neoterm.term.mappings()
+  if has_key(g:neoterm.instances, self.id)
+    let instance = "g:neoterm.instances.".self.id
+    exec "command! -complete=shellcmd Topen".self.id." silent call ".instance.".open()"
+    exec "command! -complete=shellcmd Tclose".self.id." silent call ".instance.".close()"
+    exec "command! -complete=shellcmd Tclear".self.id." silent call ".instance.".clear()"
+    exec "command! -complete=shellcmd Tkill".self.id." silent call ".instance.".kill()"
+    exec "command! -complete=shellcmd -nargs=+ T".self.id." silent call ".instance.".do(<q-args>)"
+  else
+    echoe "There is no ".self.id." neoterm."
+  end
+endfunction
+
+function! g:neoterm.term.open()
+  let current_window = g:neoterm.split()
+
+  exec "buffer " . self.buffer_id
+
+  if g:neoterm_keep_term_open
+    silent exec current_window . "wincmd w | set noinsertmode"
+  else
+    startinsert
+  end
+endfunction
+
+function! g:neoterm.term.close()
+  if bufwinnr(self.buffer_id) > 0
+    exec bufwinnr(self.buffer_id) . "hide"
+  end
+endfunction
+
+function! g:neoterm.term.do(command)
+  call self.exec([a:command, ""])
+endfunction
+
+function! g:neoterm.term.exec(command)
+  call jobsend(self.job_id, a:command)
+endfunction
+
+function! g:neoterm.term.clear()
+  call self.exec("\<c-l>")
+endfunction
+
+function! g:neoterm.term.kill()
+  call self.exec("\<c-c>")
+endfunction
+
+function! g:neoterm.term.on_stdout(job_id, data, event)
+  if has_key(self.handlers, "on_stdout")
+    call self.handlers["on_stdout"](a:job_id, a:data, a:event)
+  end
+endfunction
+
+function! g:neoterm.term.on_stderr(job_id, data, event)
+  if has_key(self.handlers, "on_stderr")
+    call self.handlers["on_stderr"](a:job_id, a:data, a:event)
+  end
+endfunction
+
+function! g:neoterm.term.on_exit(job_id, data, event)
+  if has_key(self.handlers, "on_exit")
+    call self.handlers["on_exit"](a:job_id, a:data, a:event)
+  end
+
+  call self.destroy()
+endfunction
+
+function! g:neoterm.term.destroy()
+  if has_key(g:neoterm, "repl") && get(g:neoterm.repl, "instance_id") == self.id
+    call remove(g:neoterm.repl, "instance_id")
+  end
+
+  if has_key(g:neoterm, "test") && get(g:neoterm.test, "instance_id") == self.id
+    call remove(g:neoterm.test, "instance_id")
+  end
+
+  if has_key(g:neoterm.instances, self.id)
+    call remove(g:neoterm.instances, self.id)
+  end
+endfunction

--- a/autoload/neoterm/repl.vim
+++ b/autoload/neoterm/repl.vim
@@ -1,6 +1,28 @@
+let g:neoterm.repl = {}
+
+function! g:neoterm.repl.instance()
+  if !has_key(self, "instance_id")
+    if !g:neoterm.has_any()
+      call neoterm#new(neoterm#test#handlers())
+    end
+
+    call neoterm#repl#term(g:neoterm.last_id)
+  end
+
+  return g:neoterm.instances[self.instance_id]
+endfunction
+
+function! neoterm#repl#term(id)
+  if has_key(g:neoterm.instances, a:id)
+    let g:neoterm.repl.instance_id = a:id
+  else
+    echoe "There is no ".a:id." term."
+  end
+endfunction
+
 " Internal: Sets the current REPL command.
 function! neoterm#repl#set(value)
-  if !exists('g:neoterm_repl_command')
+  if !exists("g:neoterm_repl_command")
     let g:neoterm_repl_command = a:value
   end
 endfunction
@@ -25,10 +47,5 @@ endfunction
 
 " Internal: Open the REPL, if needed, and executes the given command.
 function! s:repl_exec(command)
-  if !exists('g:neoterm_repl_loaded')
-    call neoterm#do(g:neoterm_repl_command)
-    let g:neoterm_repl_loaded = 1
-  end
-
-  call neoterm#exec(add(a:command, ''))
+  call g:neoterm.repl.instance().exec(add(a:command, ""))
 endfunction

--- a/autoload/neoterm/test.vim
+++ b/autoload/neoterm/test.vim
@@ -1,38 +1,61 @@
+let g:neoterm.test = {}
+
+function! g:neoterm.test.instance()
+  if !has_key(self, "instance_id")
+    if !g:neoterm.has_any()
+      call neoterm#new(neoterm#test#handlers())
+    end
+
+    call neoterm#test#term(g:neoterm.last_id)
+  end
+
+  return g:neoterm.instances[self.instance_id]
+endfunction
+
+function! neoterm#test#term(id)
+  if has_key(g:neoterm.instances, a:id)
+    let g:neoterm.test.instance_id = a:id
+  else
+    echoe "There is no ".a:id." term."
+  end
+endfunction
+
 " Public: Runs the current test lib with the given scope.
 function! neoterm#test#run(scope)
-  let g:neoterm_last_test_command = <sid>get_test_command(a:scope)
-  call <sid>run(g:neoterm_last_test_command)
+  let g:neoterm.test.last_command = <sid>get_test_command(a:scope)
+  call <sid>run(g:neoterm.test.last_command)
 endfunction
 
 " Public: Re-run the last test command.
 function! neoterm#test#rerun()
-  if exists('g:neoterm_last_test_command')
-    call <sid>run(g:neoterm_last_test_command)
+  if exists("g:neoterm.test.last_command")
+    call <sid>run(g:neoterm.test.last_command)
   else
-    echo 'No test has been runned.'
-  endif
+    echoe "No test has been runned."
+  end
 endfunction
 
 function! s:run(command)
   let should_hide = !neoterm#tab_has_neoterm() && g:neoterm_run_tests_bg
+
+  call g:neoterm.test.instance().clear()
+  call g:neoterm.test.instance().exec([a:command, ""])
   let g:neoterm_statusline = g:neoterm_test_status.running
 
-  call neoterm#exec(["\<c-l>", a:command, ''])
-
   if should_hide
-    call neoterm#close_buffer(g:neoterm_buffer_id)
+    call g:neoterm.test.instance().close()
   end
 endfunction
 
 " Internal: Get the command with the current test lib.
 function! s:get_test_command(scope)
-  if exists('b:neoterm_test_lib') && b:neoterm_test_lib != ''
-    let Fn = function('neoterm#test#' . b:neoterm_test_lib . '#run')
-  elseif exists('g:neoterm_test_lib') && g:neoterm_test_lib != ''
-    let Fn = function('neoterm#test#' . g:neoterm_test_lib . '#run')
+  if exists("b:neoterm_test_lib") && b:neoterm_test_lib != ""
+    let Fn = function("neoterm#test#" . b:neoterm_test_lib . "#run")
+  elseif exists("g:neoterm_test_lib") && g:neoterm_test_lib != ""
+    let Fn = function("neoterm#test#" . g:neoterm_test_lib . "#run")
   else
-    echo 'No test lib set.'
-    return ''
+    echoe "No test lib set."
+    return ""
   end
 
   return Fn(a:scope)
@@ -41,54 +64,53 @@ endfunction
 " Internal: Builds the dictionary with all test event handlers.
 function! neoterm#test#handlers()
   return  {
-        \   'on_stdout': function('s:test_result_handler'),
-        \   'on_stderr': function('s:test_result_handler'),
-        \   'on_exit': function('s:test_result_handler')
+        \   "on_stdout": function("s:test_result_handler"),
+        \   "on_stderr": function("s:test_result_handler"),
+        \   "on_exit": function("s:test_result_handler")
         \ }
 endfunction
 
 " Internal: Handle the test results using the current test library test
-" result's handler.
+" result"s handler.
 function! s:test_result_handler(job_id, data, event)
   " Only change statusline if tests were running
   if g:neoterm_statusline != g:neoterm_test_status.running
     return
   end
 
-  if a:event == 'exit'
-    let g:neoterm_statusline = a:data == '0' ?
+  if a:event == "exit"
+    let g:neoterm_statusline = a:data == "0" ?
           \ g:neoterm_test_status.success :
           \ g:neoterm_test_status.failed
   else
     try
-      let Fn = function('neoterm#test#' . g:neoterm_test_lib . '#result_handler')
+      let Fn = function("neoterm#test#" . g:neoterm_test_lib . "#result_handler")
       for line in a:data
         call Fn(line)
       endfor
-    catch 'E117'
-      return
+    catch "E117"
+      let g:neoterm_statusline = ""
     endtry
   end
 
+  redrawstatus!
   call <sid>raise_term_buffer()
 endfunction
 
 function! neoterm#test#status(status)
-  redrawstatus!
-
   if g:neoterm_statusline == g:neoterm_test_status[a:status]
     return printf(g:neoterm_test_status_format, g:neoterm_statusline)
   else
-    return ''
+    return ""
   end
 endfunction
 
 function! s:raise_term_buffer()
-  if g:neoterm_statusline == g:neoterm_test_status.failed
-        \ && g:neoterm_raise_when_tests_fail
+  if !neoterm#tab_has_neoterm()
+    if g:neoterm_statusline == g:neoterm_test_status.failed
+          \ && g:neoterm_raise_when_tests_fail
 
-    let current_window = winnr()
-    call neoterm#show()
-    silent exec current_window . "wincmd w | set noinsertmode"
+      call g:neoterm.test.instance().open()
+    end
   end
 endfunction

--- a/doc/neoterm.txt
+++ b/doc/neoterm.txt
@@ -13,6 +13,7 @@ CONTENTS                                                      *neoterm-contents*
 
 	1. Intro ............................................... |neoterm-intro|
 		1.1 What is neoterm? ................  |neoterm-what-is-neoterm|
+		1.2 Many terms support ...........  |neoterm-many-terms-support|
 	2. Commands ......................................... |neoterm-commands|
 	3. Functions ....................................... |neoterm-functions|
 	4. Options ........................................... |neoterm-options|
@@ -26,6 +27,19 @@ CONTENTS                                                      *neoterm-contents*
 neoterm is a neovim's terminal wrapper, its main goal is give an easier way to
 user interact with neovim's terminal.
 
+
+1.2 Many terms support
+
+neoterm is capable to control more than one term by time. To open a new term
+users can use |:Tnew| command. Each neoterm's term has an `ID` (neoterm job's
+name are always `neoterm-ID`). Also, each neoterm's term has its own set of
+commands suffixed by its `ID`, for instance `:T1` `command` will always send
+the command to neoterm `1`.
+
+Besides all suffixed command the user always have the canonical commands, the
+same set of commands without any suffix. Those commands will always be
+executed in the last neoterm's term.
+
 ===============================================================================
 2. Commands                                      *neoterm-cmds* *neoterm-commands*
 
@@ -33,6 +47,11 @@ user interact with neovim's terminal.
 
 Executes the given command on a neoterm terminal split. If there is a `%` in
 the given command, this will be expanded to the current file path.
+
+
+:Tnew                                                                    *:Tnew*
+
+Opens a new term buffer.
 
 
 :Tmap <command>                                                          *:Tmap*
@@ -50,6 +69,11 @@ accepted: `horizontal` and `vertical`. The default position is `horizontal`,
 but it can be changed in |g:neoterm_position|
 
 
+:TTestSetTerm <term-id>                                          *:TTestSetTerm*
+
+Chooses, or changes, the current term to run the tests.
+
+
 :TTestLib <test-lib>                                                 *:TTestLib*
 
 Chooses, or changes, the current test lib.
@@ -58,6 +82,11 @@ Chooses, or changes, the current test lib.
 :TTestClearStatus                                            *:TTestClearStatus*
 
 Clear the test result status on statusline.
+
+
+:TREPLSetTerm <term-id>                                          *:TREPLSetTerm*
+
+Chooses, or changes, the current term to run the REPL commands.
 
 
 :TREPLSend                                                          *:TREPLSend*

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -2,50 +2,82 @@ if !has("nvim")
   finish
 endif
 
-let g:neoterm_last_test_command = ''
-let g:neoterm_statusline = ''
+let g:neoterm = {
+      \ "last_id": 0,
+      \ "open": 0,
+      \ "instances": {}
+      \ }
 
-if !exists('g:neoterm_shell')
+function! g:neoterm.next_id()
+  let self.last_id += 1
+  return self.last_id
+endfunction
+
+function! g:neoterm.has_any()
+  return len(self.instances) > 0 && self.last_id > 0
+endfunction
+
+function! g:neoterm.last()
+  if self.has_any()
+    return self.instances[self.last_id]
+  end
+endfunction
+
+function! g:neoterm.split()
+  let current_window = winnr()
+
+  if g:neoterm_position == "horizontal"
+    exec "botright ".g:neoterm_size." new"
+  else
+    exec "botright vert".g:neoterm_size." new"
+  end
+
+  return current_window
+endfunction
+
+let g:neoterm_statusline = ""
+
+if !exists("g:neoterm_shell")
   let g:neoterm_shell = &sh
 end
 
-if !exists('g:neoterm_size')
-  let g:neoterm_size = ''
+if !exists("g:neoterm_size")
+  let g:neoterm_size = ""
 end
 
-if !exists('g:neoterm_test_libs')
+if !exists("g:neoterm_test_libs")
   let g:neoterm_test_libs = []
 end
 
-if !exists('g:neoterm_position')
-  let g:neoterm_position = 'horizontal'
+if !exists("g:neoterm_position")
+  let g:neoterm_position = "horizontal"
 end
 
-if !exists('g:neoterm_automap_keys')
-  let g:neoterm_automap_keys = ',tt'
+if !exists("g:neoterm_automap_keys")
+  let g:neoterm_automap_keys = ",tt"
 end
 
-if !exists('g:neoterm_keep_term_open')
+if !exists("g:neoterm_keep_term_open")
   let g:neoterm_keep_term_open = 1
 end
 
-if !exists('g:neoterm_run_tests_bg')
+if !exists("g:neoterm_run_tests_bg")
   let g:neoterm_run_tests_bg = 0
 end
 
-if !exists('g:neoterm_raise_when_tests_fail')
+if !exists("g:neoterm_raise_when_tests_fail")
   let g:neoterm_raise_when_tests_fail = 0
 end
 
-if !exists('g:neoterm_test_status_format')
-  let g:neoterm_test_status_format = '[%s]'
+if !exists("g:neoterm_test_status_format")
+  let g:neoterm_test_status_format = "[%s]"
 end
 
-if !exists('g:neoterm_test_status')
+if !exists("g:neoterm_test_status")
   let g:neoterm_test_status = {
-        \ 'running': 'RUNNING',
-        \ 'success': 'SUCCESS',
-        \ 'failed': 'FAILED'
+        \ "running": "RUNNING",
+        \ "success": "SUCCESS",
+        \ "failed": "FAILED"
         \ }
 end
 
@@ -54,24 +86,23 @@ hi! NeotermTestSuccess ctermfg=2 ctermbg=0
 hi! NeotermTestFailed ctermfg=1 ctermbg=0
 
 aug neoterm_setup
-  au TermOpen term://*NEOTERM let g:neoterm_terminal_jid = b:terminal_job_id
-  au TermOpen term://*NEOTERM let g:neoterm_buffer_id = bufnr('%')
-  au TermOpen term://*NEOTERM setlocal nonumber norelativenumber
-  au BufUnload,BufDelete,BufWipeout term://*NEOTERM
-        \ unlet! g:neoterm_terminal_jid |
-        \ unlet! g:neoterm_buffer_id |
-        \ unlet! g:neoterm_repl_loaded |
+  au!
+  au TermOpen term://*neoterm* setlocal nonumber norelativenumber
 aug END
 
-command! -range=% TREPLSendFile call neoterm#repl#selection(<line1>, <line2>)
-command! -range TREPLSend call neoterm#repl#selection(<line1>, <line2>)
-command! -complete=customlist,neoterm#test#libs#autocomplete -nargs=? TTestLib call neoterm#test#libs#add(<q-args>)
-command! TTestClearStatus let g:neoterm_statusline=''
+command! -complete=shellcmd Tnew silent call neoterm#new()
+command! -complete=shellcmd Topen silent call neoterm#open()
+command! -complete=shellcmd Tclose silent call neoterm#close()
+command! -complete=shellcmd -nargs=+ T silent call neoterm#do(<q-args>)
+command! -complete=shellcmd -nargs=+ Tmap silent call neoterm#map_for(<q-args>)
 command! -nargs=1 Tpos let g:neoterm_position=<q-args>
 
-command! -complete=shellcmd Topen call neoterm#open()
-command! -complete=shellcmd Tclose call neoterm#close_all()
-command! -complete=shellcmd -nargs=+ T call neoterm#do(<q-args>)
-command! -complete=shellcmd -nargs=+ Tmap exec "nnoremap <silent> "
-      \ . g:neoterm_automap_keys .
-      \ " :T " . neoterm#expand_cmd(<q-args>) . "<cr>"
+" REPL
+command! -complete=customlist,neoterm#list -nargs=1 TREPLSetTerm silent call neoterm#repl#term(<q-args>)
+command! -range=% TREPLSendFile silent call neoterm#repl#selection(<line1>, <line2>)
+command! -range TREPLSend silent call neoterm#repl#selection(<line1>, <line2>)
+
+" Test
+command! -complete=customlist,neoterm#list -nargs=1 TTestSetTerm silent call neoterm#test#term(<q-args>)
+command! -complete=customlist,neoterm#test#libs#autocomplete -nargs=? TTestLib silent call neoterm#test#libs#add(<q-args>)
+command! TTestClearStatus silent let g:neoterm_statusline=""


### PR DESCRIPTION
- [x] Add `:Tnew` to open new terms;
- [x] Create custom commands for each term, like `:T1`, `:T2`, `:Tclose1`, etc;
- [x] Add commands to set witch term REPL and Tests will run;
- [x] By default, commands without suffix will always run in the last neoterm's term;
- [x] Add readme documentation.

![many-terms](https://cloud.githubusercontent.com/assets/120483/8922111/0f545468-34b5-11e5-9287-db7e984f4f09.gif)

I guess this will fix #31, @Dkendal, could you tell me what you think about this solution?! 