### PR TITLE
Workaround removal off termopens 'name' feature

### DIFF
--- a/autoload/neoterm.vim
+++ b/autoload/neoterm.vim
@@ -23,14 +23,11 @@ endfunction
 "
 " Returns: 1 if a new terminal was created, 0 otherwise.
 function! neoterm#new()
-  let opts = extend(
-        \ { 'name': 'NEOTERM' },
-        \ neoterm#test#handlers()
-        \ )
+  let opts = neoterm#test#handlers()
 
   if !exists('g:neoterm_terminal_jid') " there is no neoterm running
     exec <sid>split_cmd()
-    call termopen([g:neoterm_shell], opts)
+    call termopen(g:neoterm_shell . ";#:NEOTERM", opts)
     return 1
   else
     return 0


### PR DESCRIPTION
This should address #41.

See: https://github.com/neovim/neovim/issues/3278#issuecomment-137105155