### PR TITLE
fix Python REPLs, ipython should be checked for first

### DIFF
--- a/ftdetect/set_repl_cmd.vim
+++ b/ftdetect/set_repl_cmd.vim
@@ -16,9 +16,9 @@ aug set_repl_cmd
         \ endif
   " Python
   au VimEnter,BufRead,BufNewFile *.py,
-        \ if executable('python') |
-        \   call neoterm#repl#set('python') |
-        \ elseif executable('ipython') |
+        \ if executable('ipython') |
         \   call neoterm#repl#set('ipython') |
+        \ elseif executable('python') |
+        \   call neoterm#repl#set('python') |
         \ end
 aug END


### PR DESCRIPTION
Currently IPython cannot be used, because the python executable is checked for first.