### PR TITLE
Add partial Cargo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ it's the command: `rspec spec/path/to/file_spec.rb:123`.
   * Status in statusline supported
 * go-lang test ([partially implemented](https://github.com/kassio/neoterm/pull/8))
 * nose ([partially implemented](https://github.com/kassio/neoterm/pull/9))
+* Cargo ([partially implemented](https://github.com/kassio/neoterm/pull/59))
 * npm
   * You can override the default command (`npm test`) using the
     `g:neoterm_npm_lib_cmd`

--- a/autoload/neoterm/test/cargo.vim
+++ b/autoload/neoterm/test/cargo.vim
@@ -1,0 +1,4 @@
+function! neoterm#test#cargo#run(scope)
+  let command = 'cargo test'
+  return command
+endfunction

--- a/ftdetect/cargo.vim
+++ b/ftdetect/cargo.vim
@@ -1,0 +1,3 @@
+aug neoterm_test_cargo
+  au VimEnter,BufRead,BufNewFile *.rs, call neoterm#test#libs#add('cargo')
+aug END


### PR DESCRIPTION
Hello there, thanks for this plugin.
This is a proposal to add partial [Cargo](https://crates.io/) (Rust) support for Neoterm.