### PR TITLE
Respect the value of shellcmdflag

### DIFF
--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -28,7 +28,7 @@ endfunction
 let g:neoterm_statusline = ""
 
 if !exists("g:neoterm_shell")
-  let g:neoterm_shell = &sh
+  let g:neoterm_shell = &shellcmd . ' ' . substitute(&shellcmdflag, '[-/]c', '', '')
 end
 
 if !exists("g:neoterm_size")


### PR DESCRIPTION
Strips `-c` or `/c` from `shellcmdflag`, then passes the remainder to correctly set `g:neoterm_shell`.

Addresses #91 