### PR TITLE
Check to make sure shellcmdflag exists

### DIFF
--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -28,7 +28,11 @@ endfunction
 let g:neoterm_statusline = ""
 
 if !exists("g:neoterm_shell")
-  let g:neoterm_shell = &shellcmd . ' ' . substitute(&shellcmdflag, '[-/]c', '', '')
+  if exists('&shellcmdflag')
+    let g:neoterm_shell = &shellcmd . ' ' . substitute(&shellcmdflag, '[-/]c', '', '')
+  else
+    let g:neoterm_shell = &shellcmd
+  end
 end
 
 if !exists("g:neoterm_size")


### PR DESCRIPTION
Apparently (and confusingly) the `shellcmdflag` option does not exist on some systems.

Hopefully fixes #94 and #95, but I can't reproduce those errors on my system in the first place.