### PR TITLE
Add crystal support

### DIFF
--- a/autoload/neoterm/test/crystal.vim
+++ b/autoload/neoterm/test/crystal.vim
@@ -1,0 +1,28 @@
+function! neoterm#test#crystal#run(scope)
+  let command = 'crystal spec'
+
+  if a:scope == 'file'
+    let command .= ' ' . expand('%')
+  elseif a:scope == 'current'
+    let command .= ' ' . expand('%') . ':' . line('.')
+  endif
+
+  return command
+endfunction
+
+function! neoterm#test#crystal#result_handler(line)
+  let counters = matchlist(
+        \ a:line,
+        \ '\(\d\+\|no\) failures\?'
+        \ )
+
+  if !empty(counters)
+    let failures = counters[1]
+
+    if str2nr(failures) == 0
+      let g:neoterm_statusline = g:neoterm_test_status.success
+    else
+      let g:neoterm_statusline = g:neoterm_test_status.failed
+    end
+  end
+endfunction

--- a/ftdetect/crystal.vim
+++ b/ftdetect/crystal.vim
@@ -1,0 +1,3 @@
+aug neoterm_test_crystal
+  au VimEnter,BufRead,BufNewFile *.cr, call neoterm#test#libs#add('crystal')
+aug END


### PR DESCRIPTION
This adds support for `crystal spec` which is built into the crystal compiler.

Sample output of running `,rt`
```
crystal-pg ➤ crystal spec  
............................................................................................

Finished in 410.77 milliseconds
92 examples, 0 failures, 0 errors, 0 pending
crystal-pg ➤    
```