### PR TITLE
Support custom Python REPL

### DIFF
--- a/doc/neoterm.txt
+++ b/doc/neoterm.txt
@@ -223,6 +223,13 @@ Default value: 0
 Sets what ruby REPl will be used.
 Default value: irb
 
+                                                         *g:neoterm_repl_python*
+
+Sets what python REPL will be used, and any arguments to be passed to it.
+Defaults to an empty string, in which case NeoTerm will fall back to IPython
+followed by Python.
+Default value: (empty)
+
 ===============================================================================
 4. Statusline                                    *neoterm-statusline* *statusline*
 

--- a/ftdetect/set_repl_cmd.vim
+++ b/ftdetect/set_repl_cmd.vim
@@ -13,7 +13,10 @@ if has('nvim')
           \ endif
     " Python
     au VimEnter,BufRead,BufNewFile *.py,
-          \ if executable('ipython') |
+          \ let s:argList = split(g:neoterm_repl_python) |
+          \ if len(s:argList) > 0 && executable(s:argList[0]) |
+          \   call neoterm#repl#set(g:neoterm_repl_python) |
+          \ elseif executable('ipython') |
           \   call neoterm#repl#set('ipython --no-autoindent') |
           \ elseif executable('python') |
           \   call neoterm#repl#set('python') |

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -99,6 +99,10 @@ if !exists("g:neoterm_repl_ruby")
   let g:neoterm_repl_ruby = "irb"
 end
 
+if !exists("g:neoterm_repl_python")
+  let g:neoterm_repl_python = ""
+end
+
 hi! NeotermTestRunning ctermfg=11 ctermbg=0
 hi! NeotermTestSuccess ctermfg=2 ctermbg=0
 hi! NeotermTestFailed ctermfg=1 ctermbg=0


### PR DESCRIPTION
I added a variable `g:neoterm_repl_python` to enable setting a custom Python REPL. For example one can pass additional arguments to IPython:
`let g:neoterm_repl_python = 'ipython --no-banner --no-autoindent'`

If undefined it is set to an empty string. If it cannot be used, NeoTerm falls back to IPython then Python as before.