### PR TITLE
Add REPL for PARI/GP

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ it's the command: `rspec spec/path/to/file_spec.rb:123`.
 * Julia: `julia`
 * R / R Markdown: `R`
 * Idris: `idris`
+* PARI/GP: `gp`
 
 ## other useful commands:
 

--- a/ftdetect/set_repl_cmd.vim
+++ b/ftdetect/set_repl_cmd.vim
@@ -38,6 +38,11 @@ if has('nvim')
           \ if executable('julia') |
           \   call neoterm#repl#set('julia') |
           \ end
+    " PARI/GP
+    au VimEnter,BufRead,BufNewFile *.gp,
+          \ if executable('gp') |
+          \   call neoterm#repl#set('gp') |
+          \ end
     " R
     au VimEnter,BufRead,BufNewFile *.R,*.Rmd
           \ if executable('R') |


### PR DESCRIPTION
PARI/GP is a computer algebra system with a focus on number theory.
Their homepage is at http://pari.math.u-bordeaux.fr/