### PR TITLE
add elixir describe test

### DIFF
--- a/autoload/neoterm/test/elixir.vim
+++ b/autoload/neoterm/test/elixir.vim
@@ -5,10 +5,20 @@ function! neoterm#test#elixir#run(scope)
   if a:scope == 'file'
     let command .= ' ' . path
   elseif a:scope == 'current'
-    let command .= ' ' . path . ':' . line('.')
+    let command .= ' ' . s:current(path)
   endif
 
   return command
+endfunction
+
+function! s:current(path)
+  let line = getline('.')
+
+  if line =~ 'describe'
+    return '--only describe:"' . matchstr(line, 'describe\s*"\zs.*\ze"') . '"'
+  else
+    return a:path . ':' . line('.')
+  end
 endfunction
 
 function! neoterm#test#elixir#result_handler(line)


### PR DESCRIPTION
New version of ExUnit added describe blocks and a describe filter.  This adds the ability to run the test suite for the describe string under the cursor.<br /><br />use like: `nnoremap <silent> ,rd :call neoterm#test#run('describe')<cr>`<br /><br />Never written a lick of vimscript so have at me.  I would prefer to pull describe string from anywhere in current block.  There's probably a way to do this, but I'm not sure how.<br /><br />Currently ExUnit only provides the single describe filter by giving it a string.