### PR TITLE
Select REPL by filetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,23 @@ it's the command: `rspec spec/path/to/file_spec.rb:123`.
 * Idris: `idris`
 * PARI/GP: `gp`
 
+The REPL is set using the filetype plugin so make sure to set
+```viml
+filetype plugin on
+```
+
+Most standard file extensions for the above REPLs are picked up by Neovim's default
+filetype plugins. However, there are two exceptions:
+* Julia `.jl` files, which are detected as `filetipe=lisp`
+* Idris `.idr`, `.lidr` files which are not recognised as any filetype
+To fix this, either install a suitable plugin for the language or add something like
+the following to your `init.vim`:
+```viml
+au VimEnter,BufRead,BufNewFile *.jl set filetype=julia
+au VimEnter,BufRead,BufNewFile *.idr set filetype=idris
+au VimEnter,BufRead,BufNewFile *.lidr set filetype=lidris
+```
+
 ## other useful commands:
 
 * `:T <command>`: Opens a terminal, or use an opened terminal, and runs the

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ it's the command: `rspec spec/path/to/file_spec.rb:123`.
 * Elixir: `iex`
 * Julia: `julia`
 * R / R Markdown: `R`
+* Haskell: `ghci`
 * Idris: `idris`
+* GNU Octave: `octave`
 * PARI/GP: `gp`
 
 The REPL is set using the filetype plugin so make sure to set

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ it's the command: `rspec spec/path/to/file_spec.rb:123`.
 * GNU Octave: `octave`
 * PARI/GP: `gp`
 
+### Troubleshooting
 The REPL is set using the filetype plugin so make sure to set
 ```viml
 filetype plugin on

--- a/doc/neoterm.txt
+++ b/doc/neoterm.txt
@@ -231,7 +231,7 @@ followed by Python.
 Default value: (empty)
 
 ===============================================================================
-4. Statusline                                    *neoterm-statusline* *statusline*
+5. Statusline                                    *neoterm-statusline* *statusline*
 
 To set you neoterm on your statusline, you must add the following:
 >

--- a/ftdetect/set_repl_cmd.vim
+++ b/ftdetect/set_repl_cmd.vim
@@ -1,18 +1,15 @@
 if has('nvim')
   aug set_repl_cmd
     au!
-    " Ruby
-    au VimEnter,BufRead,BufNewFile *.rb,*.erb,Rakefile
-          \ if executable(g:neoterm_repl_ruby) |
+    " Ruby and Rails
+    au FileType ruby,eruby
+          \ if executable('bundle') && filereadable('config/application.rb') |
+          \   call neoterm#repl#set('bundle exec rails console') |
+          \ elseif executable(g:neoterm_repl_ruby) |
           \   call neoterm#repl#set(g:neoterm_repl_ruby) |
           \ end
-    " Rails
-    au VimEnter,BufRead,BufNewFile *
-          \ if filereadable('config/application.rb') |
-          \   call neoterm#repl#set('bundle exec rails console') |
-          \ endif
     " Python
-    au VimEnter,BufRead,BufNewFile *.py,
+    au FileType python
           \ let s:argList = split(g:neoterm_repl_python) |
           \ if len(s:argList) > 0 && executable(s:argList[0]) |
           \   call neoterm#repl#set(g:neoterm_repl_python) |
@@ -22,34 +19,34 @@ if has('nvim')
           \   call neoterm#repl#set('python') |
           \ end
     " JavaScript
-    au BufEnter *
-          \ if &filetype == 'javascript' && executable('node') |
+    au FileType javascript
+          \ if executable('node') |
           \   call neoterm#repl#set('node') |
           \ end
     " Elixir
-    au VimEnter,BufRead,BufNewFile *
+    au FileType elixir
           \ if filereadable('config/config.exs') |
           \   call neoterm#repl#set('iex -S mix') |
           \ elseif &filetype == 'elixir' |
           \   call neoterm#repl#set('iex') |
           \ endif
     " Julia
-    au VimEnter,BufRead,BufNewFile *.jl,
+    au FileType julia
           \ if executable('julia') |
           \   call neoterm#repl#set('julia') |
           \ end
     " PARI/GP
-    au VimEnter,BufRead,BufNewFile *.gp,
+    au FileType gp
           \ if executable('gp') |
           \   call neoterm#repl#set('gp') |
           \ end
     " R
-    au VimEnter,BufRead,BufNewFile *.R,*.Rmd
+    au FileType r,rmd
           \ if executable('R') |
           \   call neoterm#repl#set('R') |
           \ end
     " Idris
-    au VimEnter,BufRead,BufNewFile *.idr,*.lidr,
+    au FileType idris,lidris
           \ if executable('idris') |
           \   call neoterm#repl#set('idris') |
           \ end

--- a/ftdetect/set_repl_cmd.vim
+++ b/ftdetect/set_repl_cmd.vim
@@ -45,10 +45,20 @@ if has('nvim')
           \ if executable('R') |
           \   call neoterm#repl#set('R') |
           \ end
+    " Octave
+    au FileType octave
+          \ if executable('octave') |
+          \   call neoterm#repl#set('octave') |
+          \ end
     " Idris
     au FileType idris,lidris
           \ if executable('idris') |
           \   call neoterm#repl#set('idris') |
+          \ end
+    " Haskell
+    au FileType haskell
+          \ if executable('ghci') |
+          \   call neoterm#repl#set('ghci') |
           \ end
   aug END
 end


### PR DESCRIPTION
This is a fairly big change to the way REPLs are selected. I understand if you don't like it but after some thought I think it's a better way of doing things (see below). Let me know what you think.

Most REPLs are selected by file extension detection. But this is generally already done by filetype plugins, which then set the filetype. So I rewrote `set_repl_cmd.vim` to select the REPL command by the filetype.

# Advantages
* leave filetype identification to dedicated plugins (e.g. julia-vim etc)
* some such plugins are smarter about filetype detection (e.g. checking top line for #!/usr/bin/elixir), and it's not worth duplicating all that code in NeoTerm
* the user can override the filetype to set the REPL (e.g. can tell vim to treat .py3 files as Python)

## Disadvantages
The main disadvantage is that this breaks Julia and Idris REPLs with a default vim installation because
* `.jl` files are identified as `filetype=lisp`, not `filetype=julia`
* `.[l]idr` files are not identified at any filetype, not `filetype=[l]idris`
This is easy to solve though: the user can either add autocommands to his/her vimrc to set the filetype, or use a plugin like julia-vim to do it for them. (I added a note about this in README.md.)

## Other notes
* Detection of `config/application.rb` for Rails and `config/config.exs` for Elixir now only work if the filetype is also `[e]ruby` or `elixir` respectively. I assume this is not a problem since you'd probably only want to use the REPL when in Ruby or Elixir code files anyway. You probably know more than me though so correct me if I'm wrong here.