### PR TITLE
Support Octave 4.x (different command)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ it's the command: `rspec spec/path/to/file_spec.rb:123`.
 * Haskell: `ghci`
 * Idris: `idris`
 * GNU Octave: `octave`
-  * For Octave 4.0.0 and later, you can enable Qt widgets (dialogs, plots, etc.) using `g:neoterm_octave_qt = 1`
+  * For Octave 4.0.0 and later, you can enable Qt widgets (dialogs, plots, etc.) using `g:neoterm_repl_octave_qt = 1`
 * MATLAB: `matlab -nodesktop -nosplash`
 * PARI/GP: `gp`
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ it's the command: `rspec spec/path/to/file_spec.rb:123`.
 * Haskell: `ghci`
 * Idris: `idris`
 * GNU Octave: `octave`
+  * For Octave 4.0.0 and later, you can enable Qt widgets (dialogs, plots, etc.) using `g:neoterm_octave_qt = 1`
 * MATLAB: `matlab -nodesktop -nosplash`
 * PARI/GP: `gp`
 

--- a/ftdetect/set_repl_cmd.vim
+++ b/ftdetect/set_repl_cmd.vim
@@ -49,10 +49,7 @@ if has('nvim')
     au FileType octave
           \ if executable('octave') |
           \   if executable('octave-cli') |
-          \     if !exists("g:neoterm_octave_qt") |
-          \       let g:neoterm_octave_qt = 0 |
-          \     end |
-          \     if g:neoterm_octave_qt |
+          \     if g:neoterm_repl_octave_qt |
           \       call neoterm#repl#set('octave --no-gui') |
           \     else |
           \       call neoterm#repl#set('octave-cli') |

--- a/ftdetect/set_repl_cmd.vim
+++ b/ftdetect/set_repl_cmd.vim
@@ -48,7 +48,18 @@ if has('nvim')
     " Octave
     au FileType octave
           \ if executable('octave') |
-          \   call neoterm#repl#set('octave') |
+          \   if executable('octave-cli') |
+          \     if !exists("g:neoterm_octave_qt") |
+          \       let g:neoterm_octave_qt = 0 |
+          \     end |
+          \     if g:neoterm_octave_qt |
+          \       call neoterm#repl#set('octave --no-gui') |
+          \     else |
+          \       call neoterm#repl#set('octave-cli') |
+          \     end |
+          \   else |
+          \     call neoterm#repl#set('octave') |
+          \   end |
           \ end
     " MATLAB
     au FileType matlab

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -103,6 +103,10 @@ if !exists("g:neoterm_repl_python")
   let g:neoterm_repl_python = ""
 end
 
+if !exists("g:neoterm_repl_octave_qt")
+  let g:neoterm_repl_octave_qt = 0
+end
+
 hi! NeotermTestRunning ctermfg=11 ctermbg=0
 hi! NeotermTestSuccess ctermfg=2 ctermbg=0
 hi! NeotermTestFailed ctermfg=1 ctermbg=0


### PR DESCRIPTION
In Octave 4.x, `octave` launches a Qt GUI by default. To get the CLI in 4.x:
* `octave --no-gui` launches a CLI session with support for Qt widgets (dialogs, plots, etc.)
* `octave-cli` launches a CLI session without Qt libs (falls back to fltk)

`octave-cli` is chosen by default. Users can set `g:neoterm_octave_qt = 1` to enable Qt widgets.

(Octave 3.x users shouldn't be affected by this PR.)