### PR TITLE
split TREPLSend to TREPLSendLine and TREPLSendSelection

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ let g:neoterm_position = 'horizontal'
 let g:neoterm_automap_keys = ',tt'
 
 nnoremap <silent> <f10> :TREPLSendFile<cr>
-nnoremap <silent> <f9> :TREPLSend<cr>
-vnoremap <silent> <f9> :TREPLSend<cr>
+nnoremap <silent> <f9> :TREPLSendLine<cr>
+vnoremap <silent> <f9> :TREPLSendSelection<cr>
 
 " run set test lib
 nnoremap <silent> ,rt :call neoterm#test#run('all')<cr>

--- a/autoload/neoterm/repl.vim
+++ b/autoload/neoterm/repl.vim
@@ -40,20 +40,18 @@ function! neoterm#repl#set(value)
 endfunction
 
 " Internal: Executes the current selection within a REPL.
-function! neoterm#repl#selection(...)
-  if getpos("'>") != [0, 0, 0, 0]
-    let [lnum1, col1] = getpos("'<")[1:2]
-    let [lnum2, col2] = getpos("'>")[1:2]
-    call setpos("'>", [0, 0, 0, 0])
-    call setpos("'<", [0, 0, 0, 0])
+function! neoterm#repl#selection()
+  let [lnum1, col1] = getpos("'<")[1:2]
+  let [lnum2, col2] = getpos("'>")[1:2]
+  let lines = getline(lnum1, lnum2)
+  let lines[-1] = lines[-1][:col2 - 1]
+  let lines[0] = lines[0][col1 - 1:]
+  call g:neoterm.repl.exec(lines)
+endfunction
 
-    let lines = getline(lnum1, lnum2)
-    let lines[-1] = lines[-1][:col2 - 1]
-    let lines[0] = lines[0][col1 - 1:]
-  else
-    let lines = getline(a:1, a:2)
-  end
-
+" Internal: Executes the current line within a REPL.
+function! neoterm#repl#line(...)
+  let lines = getline(a:1, a:2)
   call g:neoterm.repl.exec(lines)
 endfunction
 

--- a/doc/neoterm.txt
+++ b/doc/neoterm.txt
@@ -89,13 +89,17 @@ Clear the test result status on statusline.
 Chooses, or changes, the current term to run the REPL commands.
 
 
-:TREPLSend                                                          *:TREPLSend*
-
-Sends the current selection, or current line, to a REPL.
-
 :TREPLSendFile                                                  *:TREPLSendFile*
 
 Sends the current selection, or current file, to a REPL.
+
+:TREPLSendLine                                                  *:TREPLSendLine*
+
+Sends the current line to a REPL.
+
+:TREPLSendSelection                                        *:TREPLSendSelection*
+
+Sends the current selection to a REPL.
 
 :Topen                                                                  *:Topen*
 

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -126,8 +126,9 @@ command! -nargs=1 Tpos let g:neoterm_position=<q-args>
 
 " REPL
 command! -bar -complete=customlist,neoterm#list -nargs=1 TREPLSetTerm silent call neoterm#repl#term(<q-args>)
-command! -range=% TREPLSendFile silent call neoterm#repl#selection(<line1>, <line2>)
-command! -range TREPLSend silent call neoterm#repl#selection(<line1>, <line2>)
+command! -range=% TREPLSendFile silent call neoterm#repl#line(<line1>, <line2>)
+command! -range TREPLSendSelection silent call neoterm#repl#selection()
+command! -range TREPLSendLine silent call neoterm#repl#line(<line1>, <line2>)
 
 " Test
 command! -complete=customlist,neoterm#list -nargs=1 TTestSetTerm silent call neoterm#test#term(<q-args>)


### PR DESCRIPTION
close #109 

The little hack of `setpos` to check for vim mode breaks the usage of `gv`. In fact, we should define a function to each normal mode and visual mode.

The original function `TREPLSend` should be deprecated in the future.