### PR TITLE
Added REPL for PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ it's the command: `rspec spec/path/to/file_spec.rb:123`.
   * For Octave 4.0.0 and later, you can enable Qt widgets (dialogs, plots, etc.) using `g:neoterm_repl_octave_qt = 1`
 * MATLAB: `matlab -nodesktop -nosplash`
 * PARI/GP: `gp`
+* PHP: `psysh` and `php`
 
 ### Troubleshooting
 The REPL is set using the filetype plugin so make sure to set

--- a/doc/neoterm.txt
+++ b/doc/neoterm.txt
@@ -242,6 +242,14 @@ REPL is set to `octave-cli`. This setting is for Octave 4 and has no effect
 for Octave 3 users.
 Default value: `0`
 
+                                                         *g:neoterm_repl_php*
+
+Sets what php REPL will be used, and any arguments to be passed to it.
+Defaults to an empty string, in which case NeoTerm will fall back to psysh
+followed by php.
+Default value: (empty)
+
+
 ===============================================================================
 5. Statusline                                    *neoterm-statusline* *statusline*
 

--- a/ftdetect/set_repl_cmd.vim
+++ b/ftdetect/set_repl_cmd.vim
@@ -73,5 +73,14 @@ if has('nvim')
           \ if executable('ghci') |
           \   call neoterm#repl#set('ghci') |
           \ end
+    au FileType php
+          \ let s:argList = split(g:neoterm_repl_php) |
+          \ if len(s:argList) > 0 && executable(s:argList[0]) |
+          \   call neoterm#repl#set(g:neoterm_repl_php) |
+          \ elseif executable('psysh') |
+          \   call neoterm#repl#set('psysh') |
+          \ elseif executable('php') |
+          \   call neoterm#repl#set('php -a') |
+          \ end
   aug END
 end

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -107,6 +107,11 @@ if !exists("g:neoterm_repl_octave_qt")
   let g:neoterm_repl_octave_qt = 0
 end
 
+if !exists("g:neoterm_repl_php")
+  let g:neoterm_repl_php = ""
+end
+
+
 hi! NeotermTestRunning ctermfg=11 ctermbg=0
 hi! NeotermTestSuccess ctermfg=2 ctermbg=0
 hi! NeotermTestFailed ctermfg=1 ctermbg=0


### PR DESCRIPTION
I've added REPL support for PHP.
You can also specify which PHP REPL you want to use with the `neoterm_repl_php` variable based on #101 
If the variable is not defined, neoterm falls back to psysh and then to the php interactive shell.