### PR TITLE
Explicitly send a carriage return to execute

### DIFF
--- a/autoload/neoterm/repl.vim
+++ b/autoload/neoterm/repl.vim
@@ -64,5 +64,5 @@ function! g:neoterm.repl.exec(command)
     let self.loaded = 1
   end
 
-  call g:neoterm.repl.instance().exec(add(a:command, ""))
+  call g:neoterm.repl.instance().exec(add(a:command, "\r"))
 endfunction


### PR DESCRIPTION
Tested locally, seems to work. Attempt to fix https://github.com/kassio/neoterm/issues/112
