### PR TITLE
Consider using RSpec binstub before resorting to bundle exec

### DIFF
--- a/autoload/neoterm/test/rspec.vim
+++ b/autoload/neoterm/test/rspec.vim
@@ -3,6 +3,8 @@ function! neoterm#test#rspec#run(scope)
 
   if exists('g:neoterm_rspec_lib_cmd')
     let command = g:neoterm_rspec_lib_cmd
+  elseif filereadable('./bin/rspec')
+    let command = './bin/rspec'
   else
     let command = 'bundle exec rspec'
   end


### PR DESCRIPTION
Hey,

I'm a long time user of your plugin, really great work. 👍 

I was using `vim-test` for a while with `neoterm` strategy, but now switched around to using `neoterm` directly (for the status line 😄). I noticed that `neoterm` doesn't have the same heuristics for detecting how to run RSpec. I've added one heuristic that I think is the most useful at the moment: check for `./bin/rspec` before resorting to `bundle exec rspec`.

For reference, here's the same thing in `vim-test`: https://github.com/janko-m/vim-test/blob/master/autoload/test/ruby/rspec.vim#L32-L33