### PR TITLE
Don't treat | as command separator in :T

### DIFF
--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -128,7 +128,7 @@ command! -bar -complete=shellcmd Tnew silent call neoterm#tnew()
 command! -bar -complete=shellcmd Topen silent call neoterm#open()
 command! -bar -complete=shellcmd Tclose silent call neoterm#close()
 command! -bar -complete=shellcmd Ttoggle silent call neoterm#toggle()
-command! -bar -complete=shellcmd -nargs=+ T silent call neoterm#do(<q-args>)
+command! -complete=shellcmd -nargs=+ T silent call neoterm#do(<q-args>)
 command! -complete=shellcmd -nargs=+ Tmap silent call neoterm#map_for(<q-args>)
 command! -nargs=1 Tpos let g:neoterm_position=<q-args>
 


### PR DESCRIPTION
This fixes #116.

Currently, the `:T` command is declared with the `-bar` attribute, which causes the character `|` to be treated as a vim command separator.

So, trying to run the shell command `ls|grep foo` with `:T`, will execute the shell command `ls`, followed by the _vim_ command `grep foo`, instead of the shell command `ls|grep foo`.

This PR removes the `-bar` attribute in the `:T` command declaration.

Thanks for neoterm, this is awesome :)