### PR TITLE
Add option to specify default test lib

### DIFF
--- a/autoload/neoterm/test/libs.vim
+++ b/autoload/neoterm/test/libs.vim
@@ -1,12 +1,13 @@
 function! neoterm#test#libs#add(lib)
   if has('nvim')
     if index(g:neoterm_test_libs, a:lib) == -1
-      let g:neoterm_test_lib = a:lib
       call add(g:neoterm_test_libs, a:lib)
     end
-
-    let b:neoterm_test_lib = a:lib
   end
+endfunction
+
+function! neoterm#test#libs#current(lib)
+  let b:neoterm_test_lib = a:lib
 endfunction
 
 function! neoterm#test#libs#autocomplete(arg_lead, cmd_line, cursor_pos)

--- a/autoload/neoterm/test/libs.vim
+++ b/autoload/neoterm/test/libs.vim
@@ -1,13 +1,12 @@
 function! neoterm#test#libs#add(lib)
   if has('nvim')
     if index(g:neoterm_test_libs, a:lib) == -1
+      let g:neoterm_test_lib = a:lib
       call add(g:neoterm_test_libs, a:lib)
     end
-  end
-endfunction
 
-function! neoterm#test#libs#current(lib)
-  let b:neoterm_test_lib = a:lib
+    let b:neoterm_test_lib = a:lib
+  end
 endfunction
 
 function! neoterm#test#libs#autocomplete(arg_lead, cmd_line, cursor_pos)

--- a/doc/neoterm.txt
+++ b/doc/neoterm.txt
@@ -210,6 +210,12 @@ Example: >
     endfunction
     let g:neoterm_test_before_all="BeforeAll"
 <
+                                                    *g:neoterm_test_lib_primary*
+
+Sets what the primary test lib will be used, if multiple test lib is exists
+on the same file format.
+Default value: `{` `'ruby'``:` `'minitest'` `}`
+
                                                    *g:neoterm_use_relative_path*
 
 When set, the `%` will always be expanded to the file relative path, instead

--- a/ftdetect/1_testrbl.vim
+++ b/ftdetect/1_testrbl.vim
@@ -1,10 +1,10 @@
 aug neoterm_test_minitest
   au VimEnter,BufRead,BufNewFile *_test.rb
-        \ if g:neoterm_test_lib_primary == 'testrbl' |
+        \ if get(g:neoterm_test_lib_primary, 'ruby') == 'testrbl' |
         \   call neoterm#test#libs#add('testrbl') |
         \ endif
   au VimEnter *
-        \ if filereadable('test/test_helper.rb') && g:neoterm_test_lib_primary == 'testrbl' |
+        \ if filereadable('test/test_helper.rb') && get(g:neoterm_test_lib_primary, 'ruby') == 'testrbl' |
         \   call neoterm#test#libs#add('testrbl') |
         \ endif
 aug END

--- a/ftdetect/1_testrbl.vim
+++ b/ftdetect/1_testrbl.vim
@@ -1,8 +1,10 @@
 aug neoterm_test_minitest
   au VimEnter,BufRead,BufNewFile *_test.rb
-        \ call neoterm#test#libs#add('testrbl')
+        \ if g:neoterm_test_lib_primary == 'testrbl' |
+        \   call neoterm#test#libs#add('testrbl') |
+        \ endif
   au VimEnter *
-        \ if filereadable('test/test_helper.rb') |
+        \ if filereadable('test/test_helper.rb') && g:neoterm_test_lib_primary == 'testrbl' |
         \   call neoterm#test#libs#add('testrbl') |
         \ endif
 aug END

--- a/ftdetect/2_rake.vim
+++ b/ftdetect/2_rake.vim
@@ -1,8 +1,10 @@
 aug neoterm_test_minitest
   au VimEnter,BufRead,BufNewFile *_test.rb
-        \ call neoterm#test#libs#add('rake')
+        \ if g:neoterm_test_lib_primary == 'rake' |
+        \   call neoterm#test#libs#add('rake') |
+        \ endif
   au VimEnter *
-        \ if filereadable('test/test_helper.rb') |
+        \ if filereadable('test/test_helper.rb') && g:neoterm_test_lib_primary == 'rake' |
         \   call neoterm#test#libs#add('rake') |
         \ endif
 aug END

--- a/ftdetect/2_rake.vim
+++ b/ftdetect/2_rake.vim
@@ -1,10 +1,10 @@
 aug neoterm_test_minitest
   au VimEnter,BufRead,BufNewFile *_test.rb
-        \ if g:neoterm_test_lib_primary == 'rake' |
+        \ if get(g:neoterm_test_lib_primary, 'ruby') == 'rake' |
         \   call neoterm#test#libs#add('rake') |
         \ endif
   au VimEnter *
-        \ if filereadable('test/test_helper.rb') && g:neoterm_test_lib_primary == 'rake' |
+        \ if filereadable('test/test_helper.rb') && get(g:neoterm_test_lib_primary, 'ruby') == 'rake' |
         \   call neoterm#test#libs#add('rake') |
         \ endif
 aug END

--- a/ftdetect/3_minitest.vim
+++ b/ftdetect/3_minitest.vim
@@ -1,8 +1,10 @@
 aug neoterm_test_minitest
   au VimEnter,BufRead,BufNewFile *_test.rb
-        \ call neoterm#test#libs#add('minitest')
+        \ if g:neoterm_test_lib_primary == 'minitest' |
+        \   call neoterm#test#libs#add('minitest') |
+        \ endif
   au VimEnter *
-        \ if filereadable('test/test_helper.rb') |
+        \ if filereadable('test/test_helper.rb') && g:neoterm_test_lib_primary == 'minitest' |
         \   call neoterm#test#libs#add('minitest') |
         \ endif
 aug END

--- a/ftdetect/3_minitest.vim
+++ b/ftdetect/3_minitest.vim
@@ -1,10 +1,10 @@
 aug neoterm_test_minitest
   au VimEnter,BufRead,BufNewFile *_test.rb
-        \ if g:neoterm_test_lib_primary == 'minitest' |
+        \ if get(g:neoterm_test_lib_primary, 'ruby') == 'minitest' |
         \   call neoterm#test#libs#add('minitest') |
         \ endif
   au VimEnter *
-        \ if filereadable('test/test_helper.rb') && g:neoterm_test_lib_primary == 'minitest' |
+        \ if filereadable('test/test_helper.rb') && get(g:neoterm_test_lib_primary, 'ruby') == 'minitest' |
         \   call neoterm#test#libs#add('minitest') |
         \ endif
 aug END

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -43,6 +43,10 @@ if !exists("g:neoterm_test_libs")
   let g:neoterm_test_libs = []
 end
 
+if !exists("g:neoterm_test_lib")
+  let g:neoterm_test_lib = 'minitest'
+end
+
 if !exists("g:neoterm_position")
   let g:neoterm_position = "horizontal"
 end
@@ -140,5 +144,5 @@ command! -range TREPLSendLine silent call neoterm#repl#line(<line1>, <line2>)
 
 " Test
 command! -complete=customlist,neoterm#list -nargs=1 TTestSetTerm silent call neoterm#test#term(<q-args>)
-command! -complete=customlist,neoterm#test#libs#autocomplete -nargs=? TTestLib silent call neoterm#test#libs#add(<q-args>)
+command! -complete=customlist,neoterm#test#libs#autocomplete -nargs=? TTestLib silent call neoterm#test#libs#current(<q-args>)
 command! TTestClearStatus silent let g:neoterm_statusline=""

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -43,6 +43,10 @@ if !exists("g:neoterm_test_libs")
   let g:neoterm_test_libs = []
 end
 
+if !exists("g:neoterm_test_lib_primary")
+  let g:neoterm_test_lib_primary = 'minitest'
+end
+
 if !exists("g:neoterm_position")
   let g:neoterm_position = "horizontal"
 end

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -43,10 +43,6 @@ if !exists("g:neoterm_test_libs")
   let g:neoterm_test_libs = []
 end
 
-if !exists("g:neoterm_test_lib")
-  let g:neoterm_test_lib = 'minitest'
-end
-
 if !exists("g:neoterm_position")
   let g:neoterm_position = "horizontal"
 end
@@ -144,5 +140,5 @@ command! -range TREPLSendLine silent call neoterm#repl#line(<line1>, <line2>)
 
 " Test
 command! -complete=customlist,neoterm#list -nargs=1 TTestSetTerm silent call neoterm#test#term(<q-args>)
-command! -complete=customlist,neoterm#test#libs#autocomplete -nargs=? TTestLib silent call neoterm#test#libs#current(<q-args>)
+command! -complete=customlist,neoterm#test#libs#autocomplete -nargs=? TTestLib silent call neoterm#test#libs#add(<q-args>)
 command! TTestClearStatus silent let g:neoterm_statusline=""

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -44,7 +44,9 @@ if !exists("g:neoterm_test_libs")
 end
 
 if !exists("g:neoterm_test_lib_primary")
-  let g:neoterm_test_lib_primary = 'minitest'
+  let g:neoterm_test_lib_primary = {
+        \ 'ruby': 'minitest'
+        \ }
 end
 
 if !exists("g:neoterm_position")


### PR DESCRIPTION
Now, `minitest` has the highest priority in the same format.
https://github.com/kassio/neoterm/commit/36f0db478d37db320238ce15bf867b60cd73e40c

If we are using test-unit, we need to specify `:TTestLib rake` in case the scope is `file` or `current`.
On the other hand, if we use `rake` we can run the test even with `minitest`.
This pull request will allow us to select the test library to use, even if the highest priority remains `minitest`.

neoterm is so good !
Thanks ! 😀