### PR TITLE
Execute `G` when we reopen the terminal.

### DIFF
--- a/autoload/neoterm.term.vim
+++ b/autoload/neoterm.term.vim
@@ -42,6 +42,9 @@ endfunction
 function! g:neoterm.term.open()
   let l:self.origin = exists('*win_getid') ? win_getid() : 0
   call neoterm#window#reopen(l:self)
+  if g:neoterm_autoscroll
+    call l:self.normal('G')
+  end
 endfunction
 
 function! g:neoterm.term.focus_exec(cmd)

--- a/doc/neoterm.txt
+++ b/doc/neoterm.txt
@@ -212,7 +212,7 @@ Default value: ""
 							  *g:neoterm_autoscroll*
 
 When set to `1` neoterm will scroll to the end of its buffer after running any
-command.
+command or using :TOpen for when the terminal is hidden.
 Default value: `0`
 
 							   *g:neoterm_fixedsize*


### PR DESCRIPTION
So a little motivation, about why I think this change should be done:
I've set in my vimrc  `autocmd TermOpen * set bufhidden=hide` which
hides the terminal instead of closing it when using `:q`, but an
unexpected side effect was that when I execute a command while the
buffer is hidden, it would not automatically scroll down.

That's why I hooked the scroll down function on the reopen, so that when
I use `:Topen` I have the buffer scrolled down.

How I did it? Just copied the same hook in the command execution. I can
change it to a function to mitigate copying this around if you request?