### PR TITLE
add option g:neoterm_autojump

### DIFF
--- a/autoload/neoterm/window.vim
+++ b/autoload/neoterm/window.vim
@@ -39,7 +39,7 @@ function! s:after_open(origin)
 
   if g:neoterm_autoinsert
     startinsert
-  else
+  elseif !g:neoterm_autojump
     if a:origin
       call win_gotoid(a:origin)
     else

--- a/doc/neoterm.txt
+++ b/doc/neoterm.txt
@@ -166,6 +166,13 @@ Default value: `1`.
 When set, neoterm will opens in insert mode.
 Default value: `0`.
 
+							  *g:neoterm_autojump*
+
+When set, neoterm will open in normal mode, and will not go back to the
+previous window.
+When |g:neoterm_autoinsert| is set, this option has no effect.
+Default value: `0`.
+
 						       *g:neoterm_split_on_tnew*
 
 When set, |:Tnew| command will create the neoterm in a splitted window.

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -59,6 +59,10 @@ if !exists('g:neoterm_autoinsert')
   let g:neoterm_autoinsert = 0
 end
 
+if !exists('g:neoterm_autojump')
+  let g:neoterm_autojump = 0
+endif
+
 if !exists('g:neoterm_split_on_tnew')
   let g:neoterm_split_on_tnew = 1
 end


### PR DESCRIPTION
This option enables to open neoterm with keeping the focus on it without entering insert mode.