### PR TITLE
Fix bug for `:Tprevious`

### DIFF
--- a/autoload/neoterm.vim
+++ b/autoload/neoterm.vim
@@ -150,7 +150,7 @@ function! neoterm#previous()
     exec printf('%sbuffer', a:buffers[l:previous_index])
   endfunction
 
-  call s:can_navigate(function('s:next'))
+  call s:can_navigate(function('s:previous'))
 endfunction
 
 function! s:can_navigate(navigate)


### PR DESCRIPTION
Seems "neoterm#previous()" function called wrong function, it should be "s:previous" instead of "s:next". This pull request will fix this.

Thanks!