### PR TITLE
Enable REPL key mapping work with object

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ vim-test with `neoterm` strategy to replace this feature*
 
 * `TREPLSend`: sends the current line or the selection to a REPL in a terminal.
 * `TREPLSendFile`: sends the current file to a REPL in a terminal.
+* `<Plug>(neoterm-repl-send)`: sends with text-objects or motions, or sends the
+  selection to a REPL in a terminal.
+* `<Plug>(neoterm-repl-send-line)`: sends the current line to a REPL in a
+  terminal.
 
 ### REPLs supported
 
@@ -124,6 +128,12 @@ let g:neoterm_automap_keys = ',tt'
 nnoremap <silent> <f10> :TREPLSendFile<cr>
 nnoremap <silent> <f9> :TREPLSendLine<cr>
 vnoremap <silent> <f9> :TREPLSendSelection<cr>
+
+" or use keymaps that works with text-objects
+nmap gx <Plug>(neoterm-repl-send)
+xmap gx <Plug>(neoterm-repl-send)
+nmap gxx <Plug>(neoterm-repl-send-line)
+" now can use gx{text-objects} such as gxip
 
 " Useful maps
 " hide/close terminal

--- a/autoload/neoterm/repl.vim
+++ b/autoload/neoterm/repl.vim
@@ -55,6 +55,18 @@ function! neoterm#repl#line(...)
   call g:neoterm.repl.exec(l:lines)
 endfunction
 
+" Internal: Executes within a REPL, use as opfunc with g@.
+function! neoterm#repl#opfunc(type)
+  let [l:lnum1, l:col1] = getpos("'[")[1:2]
+  let [l:lnum2, l:col2] = getpos("']")[1:2]
+  let l:lines = getline(l:lnum1, l:lnum2)
+  if a:type ==# 'char'
+    let l:lines[-1] = l:lines[-1][:l:col2 - 1]
+    let l:lines[0] = l:lines[0][l:col1 - 1:]
+  endif
+  call g:neoterm.repl.exec(l:lines)
+endfunction
+
 " Internal: Open the REPL, if needed, and executes the given command.
 function! g:neoterm.repl.exec(command)
   if !l:self.loaded && !g:neoterm_direct_open_repl

--- a/doc/neoterm.txt
+++ b/doc/neoterm.txt
@@ -17,6 +17,7 @@ CONTENTS						      *neoterm-contents*
 	3. Functions ....................................... |neoterm-functions|
 	4. Options ........................................... |neoterm-options|
 	5. Statusline...................................... |neoterm-statusline|
+	6. Operators........................................ |neoterm-operators|
 
 ===============================================================================
 1. Intro							 *neoterm-intro*
@@ -242,6 +243,30 @@ Default value: `0`
 When set to `1` neoterm will automatically open a terminal window and start the
 REPL for you. If set to `0` it will leave you in the shell.
 Default value: `1`
+
+===============================================================================
+6. Operators						      *neoterm-operators*
+
+						      *<Plug>(neoterm-repl-send)*
+
+Keymap for sending contents to REPL, works with |text-objects|. For example,
+>
+    " Use gx{text-object} in normal mode
+    nmap gx <Plug>(neoterm-repl-send)
+
+    " Send selected contents in visual mode.
+    xmap gx <Plug>(neoterm-repl-send)
+<
+With those mapping, you could use `gxip` to send a paragraph to REPL, or send
+selected contents with `gx` in visual mode.
+
+						 *<Plug>(neoterm-repl-send-line)*
+
+Like |<Plug>(neoterm-repl-send)|, but for lines. For example,
+>
+    nmap gxx <Plug>(neoterm-repl-send-line)
+<
+Then you could use `gxx` or `2gxx` to send current or 2 lines to REPL.
 
 ===============================================================================
 

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -126,10 +126,6 @@ command! -range=% TREPLSendFile silent call neoterm#repl#line(<line1>, <line2>)
 command! -range TREPLSendSelection silent call neoterm#repl#selection()
 command! -range TREPLSendLine silent call neoterm#repl#line(<line1>, <line2>)
 
-function! s:TREPLSendOp(type) abort
-    call neoterm#repl#line(line("'["), line("']"))
-endfunction
-
-nnoremap <silent> <Plug>(neoterm-repl-send) :<c-u>set opfunc=<sid>TREPLSendOp<cr>g@
-xnoremap <silent> <Plug>(neoterm-repl-send) :<c-u>TREPLSendSelection<cr>
-nnoremap <silent> <Plug>(neoterm-repl-send-line) :<c-u>set opfunc=<sid>TREPLSendOp<bar>exe 'norm! 'v:count1.'g@_'<cr>
+nnoremap <silent> <Plug>(neoterm-repl-send) :<c-u>set opfunc=neoterm#repl#opfunc<cr>g@
+xnoremap <silent> <Plug>(neoterm-repl-send) :<c-u>call neoterm#repl#selection()<cr>
+nnoremap <silent> <Plug>(neoterm-repl-send-line) :<c-u>set opfunc=neoterm#repl#opfunc<bar>exe 'norm! 'v:count1.'g@_'<cr>

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -125,3 +125,11 @@ command! -bar -complete=customlist,neoterm#list -nargs=1 TREPLSetTerm silent cal
 command! -range=% TREPLSendFile silent call neoterm#repl#line(<line1>, <line2>)
 command! -range TREPLSendSelection silent call neoterm#repl#selection()
 command! -range TREPLSendLine silent call neoterm#repl#line(<line1>, <line2>)
+
+function! s:TREPLSendOp(type) abort
+    call neoterm#repl#line(line("'["), line("']"))
+endfunction
+
+nnoremap <silent> <Plug>(neoterm-repl-send) :<c-u>set opfunc=<sid>TREPLSendOp<cr>g@
+xnoremap <silent> <Plug>(neoterm-repl-send) :<c-u>TREPLSendSelection<cr>
+nnoremap <silent> <Plug>(neoterm-repl-send-line) :<c-u>set opfunc=<sid>TREPLSendOp<bar>exe 'norm! 'v:count1.'g@_'<cr>


### PR DESCRIPTION
For example, mapping with

```
nmap gx  <Plug>(neoterm-repl-send)
xmap gx  <Plug>(neoterm-repl-send)
nmap gxx <Plug>(neoterm-repl-send-line)
```

Then we could use `gx?` (such as `gxip` `gxi{` ...) to invoke REPL, sending lines with `gxx` `2gxx`... are also supported.