### PR TITLE
Add support for Vim 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ the terminal easily. All commands opens a terminal if it's not open or reuse the
 open terminal.
 REPL commands, opens a terminal and the proper REPL, if it's not opened.
 
-- NeoVim terminal helper functions/commands.
+- Compatible with Vim and NeoVim.
+- Adds functions/commands to Vim or NeoVim.
 - Wraps some REPL to receive current line or selection.
 - Many terminals support:
   - ![many-terms](https://cloud.githubusercontent.com/assets/120483/8921869/fe459572-34b1-11e5-93c9-c3b6f3b44719.gif)
@@ -97,7 +98,7 @@ vim-test with `neoterm` strategy to replace this feature*
 
 ### Troubleshooting
 
-Most standard file extensions for the above REPLs are picked up by Neovim's default
+Most standard file extensions for the above REPLs are picked up by Vim or NeoVim's default
 filetype plugins. However, there are two exceptions:
 * Julia `.jl` files, which are detected as `filetipe=lisp`
 * Idris `.idr`, `.lidr` files which are not recognised as any filetype

--- a/ftdetect/set_repl_cmd.vim
+++ b/ftdetect/set_repl_cmd.vim
@@ -1,117 +1,115 @@
-if has('nvim')
-  aug set_repl_cmd
-    au!
-    " Ruby and Rails
-    au FileType ruby,eruby
-          \ if executable('bundle') && filereadable('config/application.rb') |
-          \   call neoterm#repl#set('bundle exec rails console') |
-          \ elseif executable(g:neoterm_repl_ruby) |
-          \   call neoterm#repl#set(g:neoterm_repl_ruby) |
-          \ end
-    " Python
-    au FileType python
-          \ let s:argList = split(g:neoterm_repl_python) |
-          \ if len(s:argList) > 0 && executable(s:argList[0]) |
-          \   call neoterm#repl#set(g:neoterm_repl_python) |
-          \ elseif executable('ipython') |
-          \   call neoterm#repl#set('ipython --no-autoindent') |
-          \ elseif executable('python') |
-          \   call neoterm#repl#set('python') |
-          \ end
-    " JavaScript
-    au FileType javascript
-          \ if executable('node') |
-          \   call neoterm#repl#set('node') |
-          \ end
-    " Elixir
-    au FileType elixir
-          \ if filereadable('config/config.exs') |
-          \   call neoterm#repl#set('iex -S mix') |
-          \ elseif &filetype == 'elixir' |
-          \   call neoterm#repl#set('iex') |
-          \ endif
-    " Julia
-    au FileType julia
-          \ if executable('julia') |
-          \   call neoterm#repl#set('julia') |
-          \ end
-    " PARI/GP
-    au FileType gp
-          \ if executable('gp') |
-          \   call neoterm#repl#set('gp') |
-          \ end
-    " R
-    au FileType r,rmd
-          \ if executable('R') |
-          \   call neoterm#repl#set('R') |
-          \ end
-    " Octave
-    au FileType octave
-          \ if executable('octave') |
-          \   if executable('octave-cli') |
-          \     if g:neoterm_repl_octave_qt |
-          \       call neoterm#repl#set('octave --no-gui') |
-          \     else |
-          \       call neoterm#repl#set('octave-cli') |
-          \     end |
-          \   else |
-          \     call neoterm#repl#set('octave') |
-          \   end |
-          \ end
-    " MATLAB
-    au FileType matlab
-          \ if executable('matlab') |
-          \   call neoterm#repl#set('matlab -nodesktop -nosplash') |
-          \ end
-    " Idris
-    au FileType idris,lidris
-          \ if executable('idris') |
-          \   call neoterm#repl#set('idris') |
-          \ end
-    " Haskell
-    au FileType haskell
-          \ if executable('stack') |
-          \ call neoterm#repl#set('stack ghci') |
-          \ elseif executable('ghci') |
-          \   call neoterm#repl#set('ghci') |
-          \ end
-    au FileType php
-          \ let s:argList = split(g:neoterm_repl_php) |
-          \ if len(s:argList) > 0 && executable(s:argList[0]) |
-          \   call neoterm#repl#set(g:neoterm_repl_php) |
-          \ elseif executable('psysh') |
-          \   call neoterm#repl#set('psysh') |
-          \ elseif executable('php') |
-          \   call neoterm#repl#set('php -a') |
-          \ end
-    " Clojure
-    au FileType clojure
-          \ if executable('lein') |
-          \   call neoterm#repl#set('lein repl') |
-          \ end
-    " Lua
-    au FileType lua
-          \ if executable('luap') |
-          \   let s:lua_repl='luap' |
-          \ elseif executable('lua') |
-          \   let s:lua_repl='lua' |
-          \ endif |
-          \ if executable('luarocks') && exists('s:lua_repl') |
-          \   call neoterm#repl#set(s:lua_repl . ' -l"luarocks.require"') |
-          \ endif
-    " TCL
-    au FileType tcl
-          \ if executable('tclsh') |
-          \   call neoterm#repl#set('tclsh') |
-          \ endif
-    " Standard ML (SML)
-    au FileType sml
-          \ if executable('sml') |
-          \   if executable('rlwrap') |
-          \     call neoterm#repl#set('rlwrap sml') |
-          \   else |
-          \     call neoterm#repl#set('sml') |
-          \   endif |
-          \ endif
-  aug END
-end
+aug set_repl_cmd
+  au!
+  " Ruby and Rails
+  au FileType ruby,eruby
+        \ if executable('bundle') && filereadable('config/application.rb') |
+        \   call neoterm#repl#set('bundle exec rails console') |
+        \ elseif executable(g:neoterm_repl_ruby) |
+        \   call neoterm#repl#set(g:neoterm_repl_ruby) |
+        \ end
+  " Python
+  au FileType python
+        \ let s:argList = split(g:neoterm_repl_python) |
+        \ if len(s:argList) > 0 && executable(s:argList[0]) |
+        \   call neoterm#repl#set(g:neoterm_repl_python) |
+        \ elseif executable('ipython') |
+        \   call neoterm#repl#set('ipython --no-autoindent') |
+        \ elseif executable('python') |
+        \   call neoterm#repl#set('python') |
+        \ end
+  " JavaScript
+  au FileType javascript
+        \ if executable('node') |
+        \   call neoterm#repl#set('node') |
+        \ end
+  " Elixir
+  au FileType elixir
+        \ if filereadable('config/config.exs') |
+        \   call neoterm#repl#set('iex -S mix') |
+        \ elseif &filetype == 'elixir' |
+        \   call neoterm#repl#set('iex') |
+        \ endif
+  " Julia
+  au FileType julia
+        \ if executable('julia') |
+        \   call neoterm#repl#set('julia') |
+        \ end
+  " PARI/GP
+  au FileType gp
+        \ if executable('gp') |
+        \   call neoterm#repl#set('gp') |
+        \ end
+  " R
+  au FileType r,rmd
+        \ if executable('R') |
+        \   call neoterm#repl#set('R') |
+        \ end
+  " Octave
+  au FileType octave
+        \ if executable('octave') |
+        \   if executable('octave-cli') |
+        \     if g:neoterm_repl_octave_qt |
+        \       call neoterm#repl#set('octave --no-gui') |
+        \     else |
+        \       call neoterm#repl#set('octave-cli') |
+        \     end |
+        \   else |
+        \     call neoterm#repl#set('octave') |
+        \   end |
+        \ end
+  " MATLAB
+  au FileType matlab
+        \ if executable('matlab') |
+        \   call neoterm#repl#set('matlab -nodesktop -nosplash') |
+        \ end
+  " Idris
+  au FileType idris,lidris
+        \ if executable('idris') |
+        \   call neoterm#repl#set('idris') |
+        \ end
+  " Haskell
+  au FileType haskell
+        \ if executable('stack') |
+        \ call neoterm#repl#set('stack ghci') |
+        \ elseif executable('ghci') |
+        \   call neoterm#repl#set('ghci') |
+        \ end
+  au FileType php
+        \ let s:argList = split(g:neoterm_repl_php) |
+        \ if len(s:argList) > 0 && executable(s:argList[0]) |
+        \   call neoterm#repl#set(g:neoterm_repl_php) |
+        \ elseif executable('psysh') |
+        \   call neoterm#repl#set('psysh') |
+        \ elseif executable('php') |
+        \   call neoterm#repl#set('php -a') |
+        \ end
+  " Clojure
+  au FileType clojure
+        \ if executable('lein') |
+        \   call neoterm#repl#set('lein repl') |
+        \ end
+  " Lua
+  au FileType lua
+        \ if executable('luap') |
+        \   let s:lua_repl='luap' |
+        \ elseif executable('lua') |
+        \   let s:lua_repl='lua' |
+        \ endif |
+        \ if executable('luarocks') && exists('s:lua_repl') |
+        \   call neoterm#repl#set(s:lua_repl . ' -l"luarocks.require"') |
+        \ endif
+  " TCL
+  au FileType tcl
+        \ if executable('tclsh') |
+        \   call neoterm#repl#set('tclsh') |
+        \ endif
+  " Standard ML (SML)
+  au FileType sml
+        \ if executable('sml') |
+        \   if executable('rlwrap') |
+        \     call neoterm#repl#set('rlwrap sml') |
+        \   else |
+        \     call neoterm#repl#set('sml') |
+        \   endif |
+        \ endif
+aug END

--- a/ftdetect/set_repl_cmd.vim
+++ b/ftdetect/set_repl_cmd.vim
@@ -1,115 +1,117 @@
-aug set_repl_cmd
-  au!
-  " Ruby and Rails
-  au FileType ruby,eruby
-        \ if executable('bundle') && filereadable('config/application.rb') |
-        \   call neoterm#repl#set('bundle exec rails console') |
-        \ elseif executable(g:neoterm_repl_ruby) |
-        \   call neoterm#repl#set(g:neoterm_repl_ruby) |
-        \ end
-  " Python
-  au FileType python
-        \ let s:argList = split(g:neoterm_repl_python) |
-        \ if len(s:argList) > 0 && executable(s:argList[0]) |
-        \   call neoterm#repl#set(g:neoterm_repl_python) |
-        \ elseif executable('ipython') |
-        \   call neoterm#repl#set('ipython --no-autoindent') |
-        \ elseif executable('python') |
-        \   call neoterm#repl#set('python') |
-        \ end
-  " JavaScript
-  au FileType javascript
-        \ if executable('node') |
-        \   call neoterm#repl#set('node') |
-        \ end
-  " Elixir
-  au FileType elixir
-        \ if filereadable('config/config.exs') |
-        \   call neoterm#repl#set('iex -S mix') |
-        \ elseif &filetype == 'elixir' |
-        \   call neoterm#repl#set('iex') |
-        \ endif
-  " Julia
-  au FileType julia
-        \ if executable('julia') |
-        \   call neoterm#repl#set('julia') |
-        \ end
-  " PARI/GP
-  au FileType gp
-        \ if executable('gp') |
-        \   call neoterm#repl#set('gp') |
-        \ end
-  " R
-  au FileType r,rmd
-        \ if executable('R') |
-        \   call neoterm#repl#set('R') |
-        \ end
-  " Octave
-  au FileType octave
-        \ if executable('octave') |
-        \   if executable('octave-cli') |
-        \     if g:neoterm_repl_octave_qt |
-        \       call neoterm#repl#set('octave --no-gui') |
-        \     else |
-        \       call neoterm#repl#set('octave-cli') |
-        \     end |
-        \   else |
-        \     call neoterm#repl#set('octave') |
-        \   end |
-        \ end
-  " MATLAB
-  au FileType matlab
-        \ if executable('matlab') |
-        \   call neoterm#repl#set('matlab -nodesktop -nosplash') |
-        \ end
-  " Idris
-  au FileType idris,lidris
-        \ if executable('idris') |
-        \   call neoterm#repl#set('idris') |
-        \ end
-  " Haskell
-  au FileType haskell
-        \ if executable('stack') |
-        \ call neoterm#repl#set('stack ghci') |
-        \ elseif executable('ghci') |
-        \   call neoterm#repl#set('ghci') |
-        \ end
-  au FileType php
-        \ let s:argList = split(g:neoterm_repl_php) |
-        \ if len(s:argList) > 0 && executable(s:argList[0]) |
-        \   call neoterm#repl#set(g:neoterm_repl_php) |
-        \ elseif executable('psysh') |
-        \   call neoterm#repl#set('psysh') |
-        \ elseif executable('php') |
-        \   call neoterm#repl#set('php -a') |
-        \ end
-  " Clojure
-  au FileType clojure
-        \ if executable('lein') |
-        \   call neoterm#repl#set('lein repl') |
-        \ end
-  " Lua
-  au FileType lua
-        \ if executable('luap') |
-        \   let s:lua_repl='luap' |
-        \ elseif executable('lua') |
-        \   let s:lua_repl='lua' |
-        \ endif |
-        \ if executable('luarocks') && exists('s:lua_repl') |
-        \   call neoterm#repl#set(s:lua_repl . ' -l"luarocks.require"') |
-        \ endif
-  " TCL
-  au FileType tcl
-        \ if executable('tclsh') |
-        \   call neoterm#repl#set('tclsh') |
-        \ endif
-  " Standard ML (SML)
-  au FileType sml
-        \ if executable('sml') |
-        \   if executable('rlwrap') |
-        \     call neoterm#repl#set('rlwrap sml') |
-        \   else |
-        \     call neoterm#repl#set('sml') |
-        \   endif |
-        \ endif
-aug END
+if has('nvim') || has('ternminal')
+  aug set_repl_cmd
+    au!
+    " Ruby and Rails
+    au FileType ruby,eruby
+          \ if executable('bundle') && filereadable('config/application.rb') |
+          \   call neoterm#repl#set('bundle exec rails console') |
+          \ elseif executable(g:neoterm_repl_ruby) |
+          \   call neoterm#repl#set(g:neoterm_repl_ruby) |
+          \ end
+    " Python
+    au FileType python
+          \ let s:argList = split(g:neoterm_repl_python) |
+          \ if len(s:argList) > 0 && executable(s:argList[0]) |
+          \   call neoterm#repl#set(g:neoterm_repl_python) |
+          \ elseif executable('ipython') |
+          \   call neoterm#repl#set('ipython --no-autoindent') |
+          \ elseif executable('python') |
+          \   call neoterm#repl#set('python') |
+          \ end
+    " JavaScript
+    au FileType javascript
+          \ if executable('node') |
+          \   call neoterm#repl#set('node') |
+          \ end
+    " Elixir
+    au FileType elixir
+          \ if filereadable('config/config.exs') |
+          \   call neoterm#repl#set('iex -S mix') |
+          \ elseif &filetype == 'elixir' |
+          \   call neoterm#repl#set('iex') |
+          \ endif
+    " Julia
+    au FileType julia
+          \ if executable('julia') |
+          \   call neoterm#repl#set('julia') |
+          \ end
+    " PARI/GP
+    au FileType gp
+          \ if executable('gp') |
+          \   call neoterm#repl#set('gp') |
+          \ end
+    " R
+    au FileType r,rmd
+          \ if executable('R') |
+          \   call neoterm#repl#set('R') |
+          \ end
+    " Octave
+    au FileType octave
+          \ if executable('octave') |
+          \   if executable('octave-cli') |
+          \     if g:neoterm_repl_octave_qt |
+          \       call neoterm#repl#set('octave --no-gui') |
+          \     else |
+          \       call neoterm#repl#set('octave-cli') |
+          \     end |
+          \   else |
+          \     call neoterm#repl#set('octave') |
+          \   end |
+          \ end
+    " MATLAB
+    au FileType matlab
+          \ if executable('matlab') |
+          \   call neoterm#repl#set('matlab -nodesktop -nosplash') |
+          \ end
+    " Idris
+    au FileType idris,lidris
+          \ if executable('idris') |
+          \   call neoterm#repl#set('idris') |
+          \ end
+    " Haskell
+    au FileType haskell
+          \ if executable('stack') |
+          \ call neoterm#repl#set('stack ghci') |
+          \ elseif executable('ghci') |
+          \   call neoterm#repl#set('ghci') |
+          \ end
+    au FileType php
+          \ let s:argList = split(g:neoterm_repl_php) |
+          \ if len(s:argList) > 0 && executable(s:argList[0]) |
+          \   call neoterm#repl#set(g:neoterm_repl_php) |
+          \ elseif executable('psysh') |
+          \   call neoterm#repl#set('psysh') |
+          \ elseif executable('php') |
+          \   call neoterm#repl#set('php -a') |
+          \ end
+    " Clojure
+    au FileType clojure
+          \ if executable('lein') |
+          \   call neoterm#repl#set('lein repl') |
+          \ end
+    " Lua
+    au FileType lua
+          \ if executable('luap') |
+          \   let s:lua_repl='luap' |
+          \ elseif executable('lua') |
+          \   let s:lua_repl='lua' |
+          \ endif |
+          \ if executable('luarocks') && exists('s:lua_repl') |
+          \   call neoterm#repl#set(s:lua_repl . ' -l"luarocks.require"') |
+          \ endif
+    " TCL
+    au FileType tcl
+          \ if executable('tclsh') |
+          \   call neoterm#repl#set('tclsh') |
+          \ endif
+    " Standard ML (SML)
+    au FileType sml
+          \ if executable('sml') |
+          \   if executable('rlwrap') |
+          \     call neoterm#repl#set('rlwrap sml') |
+          \   else |
+          \     call neoterm#repl#set('sml') |
+          \   endif |
+          \ endif
+  aug END
+endif

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -1,4 +1,4 @@
-if get(g:, 'neoterm_loaded', 0)
+if (!has('nvim') && !has('terminal')) || get(g:, 'neoterm_loaded', 0)
   finish
 endif
 
@@ -28,7 +28,7 @@ endfunction
 let g:neoterm_statusline = ''
 
 if !exists('g:neoterm_shell')
-  if exists('&shellcmdflag') && has('nvim')
+  if has('nvim') && exists('&shellcmdflag')
     let g:neoterm_shell = &shell . ' ' . substitute(&shellcmdflag, '[-/]c', '', '')
   else
     let g:neoterm_shell = &shell

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -1,4 +1,4 @@
-if !has('nvim') || get(g:, 'neoterm_loaded', 0)
+if get(g:, 'neoterm_loaded', 0)
   finish
 endif
 
@@ -28,7 +28,7 @@ endfunction
 let g:neoterm_statusline = ''
 
 if !exists('g:neoterm_shell')
-  if exists('&shellcmdflag')
+  if exists('&shellcmdflag') && has('nvim')
     let g:neoterm_shell = &shell . ' ' . substitute(&shellcmdflag, '[-/]c', '', '')
   else
     let g:neoterm_shell = &shell


### PR DESCRIPTION
I did some tests and it works surprisingly well. I can open and close terms, send Repl commands, etc. More tests are necessary.

Maybe can extract function with `has('nvim')` and creates function like

```
function! g:neoterm.term.create(name, instance)
...
endfunction
```

We can also create other objects to do something like `g:neoterm.term.neovim.new(name, instance)` and `g:neoterm.term.vim.new(name,instance)` and the same for exec. The goal is to have all things specific to the editor in the same place.

What do you think?