### PR TITLE
Fix ipython indenting issues with bracketed paste

### DIFF
--- a/autoload/neoterm/repl.vim
+++ b/autoload/neoterm/repl.vim
@@ -34,8 +34,21 @@ function! neoterm#repl#term(id)
   end
 endfunction
 
-function! neoterm#repl#set(value)
+function! neoterm#repl#set(value, ...)
   let g:neoterm_repl_command = a:value
+  if a:0
+    let s:neoterm_repl_preprocessor = a:1
+  else
+    unlet s:neoterm_repl_preprocessor
+  endif
+endfunction
+
+function! s:preprocess(command)
+  if exists('s:neoterm_repl_preprocessor')
+    return s:neoterm_repl_preprocessor(a:command)
+  else
+    return a:command
+  endif
 endfunction
 
 function! neoterm#repl#selection()
@@ -47,23 +60,25 @@ function! neoterm#repl#selection()
   let l:lines = getline(l:lnum1, l:lnum2)
   let l:lines[-1] = l:lines[-1][:l:col2 - 1]
   let l:lines[0] = l:lines[0][l:col1 - 1:]
-  call g:neoterm.repl.exec(l:lines)
+  call g:neoterm.repl.exec(s:preprocess(l:lines))
 endfunction
 
 function! neoterm#repl#line(...)
   let l:lines = getline(a:1, a:2)
-  call g:neoterm.repl.exec(l:lines)
+  call g:neoterm.repl.exec(s:preprocess(l:lines))
 endfunction
 
 function! neoterm#repl#opfunc(type)
   let [l:lnum1, l:col1] = getpos("'[")[1:2]
   let [l:lnum2, l:col2] = getpos("']")[1:2]
   let l:lines = getline(l:lnum1, l:lnum2)
-  if a:type ==# 'char'
-    let l:lines[-1] = l:lines[-1][:l:col2 - 1]
-    let l:lines[0] = l:lines[0][l:col1 - 1:]
+  if len(l:lines)
+    if a:type ==# 'char'
+      let l:lines[-1] = l:lines[-1][:l:col2 - 1]
+      let l:lines[0] = l:lines[0][l:col1 - 1:]
+    endif
+    call g:neoterm.repl.exec(s:preprocess(l:lines))
   endif
-  call g:neoterm.repl.exec(l:lines)
 endfunction
 
 function! g:neoterm.repl.exec(command)

--- a/ftdetect/set_repl_cmd.vim
+++ b/ftdetect/set_repl_cmd.vim
@@ -9,12 +9,25 @@ if has('nvim')
           \   call neoterm#repl#set(g:neoterm_repl_ruby) |
           \ end
     " Python
+    function! s:ipython_preprocess(command)
+      if type(a:command) == v:t_list && len(a:command) > 1
+        let command = a:command
+        " Use bracketed paste to avoid autoindenting lines
+        let command[0] = "\<esc>[200~". command[0]
+        let command[-1] = command[-1] . "\<esc>[201~"
+        " Send an extra line so indented code is fully processed
+        return command + [""]
+      else
+        return a:command
+      endif
+    endfunction
+
     au FileType python
           \ let s:argList = split(g:neoterm_repl_python) |
           \ if len(s:argList) > 0 && executable(s:argList[0]) |
           \   call neoterm#repl#set(g:neoterm_repl_python) |
           \ elseif executable('ipython') |
-          \   call neoterm#repl#set('ipython --no-autoindent') |
+          \   call neoterm#repl#set('ipython --no-autoindent', function('s:ipython_preprocess')) |
           \ elseif executable('python') |
           \   call neoterm#repl#set('python') |
           \ end


### PR DESCRIPTION
ipython autoindents code as it is typed in. This causes code like this

```python
def fn(x):
    y = x + 1
    return y
```

to be indented incorrectly.

The fix is to use [bracketed pasted mode](https://cirw.in/blog/bracketed-paste)