### PR TITLE
Update docs with revamp syntax

### DIFF
--- a/doc/neoterm.txt
+++ b/doc/neoterm.txt
@@ -32,11 +32,11 @@ user interact with neovim's terminal.
 neoterm is capable to control more than one term by time. To open a new term
 users can use |:Tnew| command. Each neoterm's term has an `ID` (neoterm job's
 name are always `neoterm-ID`). Also, each neoterm's term has its own set of
-commands suffixed by its `ID`, for instance `:T1` `command` will always send
+commands prefixed by its `ID`, for instance `:1T` `command` will always send
 the command to neoterm `1`.
 
-Besides all suffixed command the user always have the canonical commands, the
-same set of commands without any suffix. Those commands will always be
+Besides all prefixed command the user always have the canonical commands, the
+same set of commands without any prefix. Those commands will always be
 executed in the last active neoterm.
 
 ===============================================================================


### PR DESCRIPTION
Update docs with revamp syntax where terminal ID should prefix command instead of suffix.