### PR TITLE
fix mess window size when quickfix opened

### DIFF
--- a/autoload/neoterm.vim
+++ b/autoload/neoterm.vim
@@ -211,6 +211,7 @@ function! s:create_window(instance)
       let l:cmd .= printf(' +buffer%s', a:instance.buffer_id)
     end
     exec l:cmd
+    exec('resize ' .g:neoterm_size)
 
     let &hidden=l:hidden
   end


### PR DESCRIPTION
Currently, the `g:neoterm_size` won't take effect if quickfix window is
opened. This PR will fix this issue.