### PR TITLE
Add g:neoterm_command_prefix option (to help out when a REPL uses vi-mode line editing)

### DIFF
--- a/autoload/neoterm/term.vim
+++ b/autoload/neoterm/term.vim
@@ -31,7 +31,11 @@ function! s:term.normal(cmd)
 endfunction
 
 function! s:term.exec(command)
-  call l:self.termsend(l:self.termid, a:command)
+  if !empty(g:neoterm_command_prefix)
+     call l:self.termsend(l:self.termid, [g:neoterm_command_prefix . a:command[0]] + a:command[1:])
+  else
+      call l:self.termsend(l:self.termid, a:command)
+  end
   if g:neoterm_autoscroll
     call l:self.normal('G')
   end

--- a/doc/neoterm.txt
+++ b/doc/neoterm.txt
@@ -269,6 +269,16 @@ Sets the shell used inside neoterm.
 neovim default: `&shell . ' ' . substitute(&shellcmdflag, '[-/]c', '', '')`
 vim default: `&shell`
 
+                                                      *g:neoterm_command_prefix*
+
+When set, is used as the prefix to any text sent to the neoterm terminal.
+This can be useful if your shell or REPL is configured to use vi-mode editing
+to ensure the mode is set to insertion mode.   For instance when using a shell
+or REPL in vi-mode, setting this to `"\edda"` will clear the current line then
+leave the prompt in insertion mode.
+Default value: ''
+
+
 ===============================================================================
 6. Operators						     *neoterm-operators*
 

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -109,6 +109,10 @@ if !exists('g:neoterm_auto_repl_cmd')
   let g:neoterm_auto_repl_cmd = 1
 end
 
+if !exists('g:neoterm_command_prefix')
+    let g:neoterm_command_prefix = ''
+end
+
 if exists('g:neoterm_position')
   echoe '*g:neoterm_position* DEPRECATED! see :help g:neoterm_position'
 end


### PR DESCRIPTION
# Problem A:

1. The REPL uses GNU readline set to vi-mode, and is currently waiting in command mode.
2. The user uses neoterm to send some text to the REPL.
3. readline begins interpreting the sent text as vi command mode input, causing unpredictable behavior.

## Proposed Solution A:

Send the text `\ea` first, to put readline into command mode then into append mode, assuring that the rest of the text sent is not accidentally interpreted by readline in command mode.

# Problem B:

1.  The REPL's current line is not blank, but contains a partially typed command the user absentmindedly forgot about.
2. The user uses neoterm to send new text to the REPL.
3. The new text is appended to the old text, causing unpredictable behavior.

## Proposed Solution B

Send the text `\edda` first, to put readline into command mode, delete the current line, then put readline back into append mode.

# Proposed Implementation:

`g:neoterm_command_prefix `

When set, is used as the prefix to any text sent to the neoterm terminal.

Default value: ''

`g:neoterm_command_prefix` is appended to the first element of the command list passed to term.exec in term.vim.  Subsequent lines are not prefixed.