### PR TITLE
Implement bracketed paste

### DIFF
--- a/autoload/neoterm/repl.vim
+++ b/autoload/neoterm/repl.vim
@@ -63,13 +63,21 @@ function! neoterm#repl#opfunc(type)
   let [l:lnum1, l:col1] = getpos("'[")[1:2]
   let [l:lnum2, l:col2] = getpos("']")[1:2]
   let l:lines = getline(l:lnum1, l:lnum2)
-  if a:type ==# 'char'
-    let l:lines[-1] = l:lines[-1][:l:col2 - 1]
-    let l:lines[0] = l:lines[0][l:col1 - 1:]
+  if len(l:lines)
+    if a:type ==# 'char'
+      let l:lines[-1] = l:lines[-1][:l:col2 - 1]
+      let l:lines[0] = l:lines[0][l:col1 - 1:]
+    endif
+    call g:neoterm.repl.exec(l:lines)
   endif
-  call g:neoterm.repl.exec(l:lines)
 endfunction
 
 function! g:neoterm.repl.exec(command)
-  call g:neoterm.repl.instance().exec(add(a:command, g:neoterm_eof))
+  let l:command = a:command
+  if exists('b:neoterm_enable_bracketed_paste')
+        \ && b:neoterm_enable_bracketed_paste
+    let l:command[0] = "\<esc>[200~". l:command[0] 
+    let l:command[-1] = l:command[-1] . "\<esc>[201~" 
+  endif
+  call g:neoterm.repl.instance().exec(add(l:command, g:neoterm_eof))
 endfunction

--- a/ftdetect/set_repl_cmd.vim
+++ b/ftdetect/set_repl_cmd.vim
@@ -10,6 +10,7 @@ if has('nvim') || has('terminal')
           \ end
     " Python
     au FileType python
+          \ let b:neoterm_enable_bracketed_paste = v:true |
           \ let s:argList = split(g:neoterm_repl_python) |
           \ if len(s:argList) > 0 && executable(s:argList[0]) |
           \   call neoterm#repl#set(g:neoterm_repl_python) |


### PR DESCRIPTION
controlled by `b:neoterm_enable_bracketed_paste` which is set to true by
default for python in the `ftdetect` autocommand.