### PR TITLE
keep_term_open also keeps hidden terminals open

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ Open a pull request to add REPLs and other features to this plugin. :smiley:
 
 ## Changelog
 
+* 07/06/2019
+  - `g:neoterm_keep_term_open` keeps hidden terminals open even if they are
+    closed without using `:Tclose`
 * 11/03/2019
   - Make the `signcolumn=auto` in neoterm buffer.
 * 29/01/2019

--- a/autoload/neoterm.vim
+++ b/autoload/neoterm.vim
@@ -94,6 +94,10 @@ function! s:after_open(instance)
     setlocal winfixheight winfixwidth
   end
 
+  if g:neoterm_keep_term_open
+    setlocal bufhidden=hide
+  end
+
   if g:neoterm_autoinsert
     startinsert
   elseif !g:neoterm_autojump

--- a/doc/neoterm.txt
+++ b/doc/neoterm.txt
@@ -171,8 +171,9 @@ Default value: `0`.
 
                                                       *g:neoterm_keep_term_open*
 
-When set, neoterm terminal will be kept running in background. When not set,
-`:bdelete!` is used to close neoterm in |:Tclose|.
+When set, neoterm terminal will be kept running in background when the buffer
+is hidden, or when closing via |:Tclose|. When not set, `:bdelete!` is used to
+close neoterm in |:Tclose|.
 Default value: `1`.
 
                                                           *g:neoterm_autoinsert*


### PR DESCRIPTION
Thanks for a great plugin!

This PR uses the value of `g:neoterm_keep_term_open` to prevent hidden terminal buffers from being closed. I often switch between files and terminal buffers, and without this my terminal buffers keep getting deleted.

Happy to consider a different config option if you're OK with the idea but don't want to overload `keep_term_open`.