### PR TITLE
Append g:neoterm_eof to each line of the commands

### DIFF
--- a/autoload/neoterm/repl.vim
+++ b/autoload/neoterm/repl.vim
@@ -71,5 +71,5 @@ function! neoterm#repl#opfunc(type)
 endfunction
 
 function! g:neoterm.repl.exec(command)
-  call g:neoterm.repl.instance().exec(add(a:command, g:neoterm_eof))
+  call g:neoterm.repl.instance().exec(map(a:command, 'v:val.g:neoterm_eof'))
 endfunction


### PR DESCRIPTION
This should be able to fix https://github.com/kassio/neoterm/issues/112#issuecomment-300993644 and  https://github.com/kassio/neoterm/issues/171#issuecomment-344751908 .

Maybe we need `g:neoterm_eol` instead?