### PR TITLE
Add support for evcxr (Rust REPL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ stored in `%USERPROFILE%\_vimrc`.
 * Racket: `racket`
 * Rails: `bundle exec rails console`
 * Ruby: `pry` and `irb`
+* Rust: `evcxr`
 * SML: `rlwrap sml` or `sml`
 * Scala: `sbt console`
 * TCL: `tclsh`
@@ -150,6 +151,8 @@ Open a pull request to add REPLs and other features to this plugin. :smiley:
 
 ## Changelog
 
+* 14/02/2020
+  - Add support for [`evcxr`](https://github.com/google/evcxr)(Rust REPL).
 * 11/11/2019
   - Fix bug with `g:neoterm_fixedsize`. ([\#255](https://github.com/kassio/neoterm/issues/255))
 * 07/11/2019

--- a/ftdetect/set_repl_cmd.vim
+++ b/ftdetect/set_repl_cmd.vim
@@ -128,5 +128,10 @@ if has('nvim') || has('terminal')
           \ if executable('lfe') |
           \   call neoterm#repl#set('lfe') |
           \ end
+    " Rust
+    au FileType rust
+          \ if executable('evcxr') |
+          \   call neoterm#repl#set('evcxr')
+          \ end
   aug END
 end


### PR DESCRIPTION
I added the support for rust REPL [`evcxr`](https://github.com/google/evcxr).

I only added 5 lines to `set_repl_cmd.vim` and it seems work well in my environment. However, I'm not sure that these changes are enough.  If there are any mistake in my PR, tell me them.