### PR TITLE
Fix issue with autocmd command for rust

### DIFF
--- a/ftdetect/set_repl_cmd.vim
+++ b/ftdetect/set_repl_cmd.vim
@@ -131,7 +131,7 @@ if has('nvim') || has('terminal')
     " Rust
     au FileType rust
           \ if executable('evcxr') |
-          \   call neoterm#repl#set('evcxr')
+          \   call neoterm#repl#set('evcxr') |
           \ end
   aug END
 end


### PR DESCRIPTION
This was probably just a typo here: https://github.com/kassio/neoterm/pull/258/files#diff-e9e5ddb44756b85b7e71f8ec6e012392R134.

For me, it caused that some other configurations for rust files were not loading correctly.