### PR TITLE
Added support for jshell (Java REPL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ stored in `%USERPROFILE%\_vimrc`.
 * Haskell: `ghci`
 * Idris: `idris`
 * JavaScript: `node`
+* Java: `java`
 * Julia: `julia`
 * LFE: `lfe`
 * Lua with `lua` and `luap`.
@@ -151,6 +152,8 @@ Open a pull request to add REPLs and other features to this plugin. :smiley:
 
 ## Changelog
 
+* 14/03/2020
+  - Add support for [`jshell`](https://github.com/christo-auer/neoterm.git)(Java REPL).
 * 14/02/2020
   - Add support for [`evcxr`](https://github.com/google/evcxr)(Rust REPL).
 * 11/11/2019

--- a/ftdetect/set_repl_cmd.vim
+++ b/ftdetect/set_repl_cmd.vim
@@ -23,6 +23,11 @@ if has('nvim') || has('terminal')
           \ if executable('node') |
           \   call neoterm#repl#set('node') |
           \ end
+    " Java
+    au FileType java
+          \ if executable('jshell') |
+          \   call neoterm#repl#set('jshell') |
+          \ end
     " Elixir
     au FileType elixir
           \ if filereadable('config/config.exs') |


### PR DESCRIPTION
Added support for jshell (Java REPL), tested it and it works (was simple enough :-) ). jshell comes with any JDK installation.