### PR TITLE
Add g:neoterm_repl_r option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 08/04/2020
+
+  - Add option `g:neoterm_repl_r` to set the REPL for the R files.
+
 ### 04/04/2020
   - Improve the documentation.
   - Change default behavior to not delete the current buffer, instead creates a

--- a/doc/neoterm.txt
+++ b/doc/neoterm.txt
@@ -225,7 +225,7 @@ Default value: 0
 
                                                            *g:neoterm_repl_ruby*
 
-Sets what ruby REPl will be used.
+Sets what ruby REPL will be used.
 Default value: irb
 
                                                          *g:neoterm_repl_python*
@@ -234,6 +234,11 @@ Sets what python REPL will be used, and any arguments to be passed to it.
 Defaults to an empty string, in which case NeoTerm will fall back to IPython
 followed by Python.
 Default value: (empty)
+
+                                                              *g:neoterm_repl_r*
+
+Sets what R REPL will be used.
+Default value: R
 
                                                       *g:neoterm_repl_octave_qt*
 

--- a/ftdetect/set_repl_cmd.vim
+++ b/ftdetect/set_repl_cmd.vim
@@ -47,7 +47,9 @@ if has('nvim') || has('terminal')
           \ end
     " R
     au FileType r,rmd
-          \ if executable('R') |
+          \ if executable(g:neoterm_repl_r) |
+          \   call neoterm#repl#set(g:neoterm_repl_r) |
+          \ elseif executable('R') |
           \   call neoterm#repl#set('R') |
           \ end
     " Octave

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -82,6 +82,10 @@ if !exists('g:neoterm_repl_python')
   let g:neoterm_repl_python = ''
 end
 
+if !exists('g:neoterm_repl_r')
+  let g:neoterm_repl_r = 'R'
+end
+
 if !exists('g:neoterm_repl_octave_qt')
   let g:neoterm_repl_octave_qt = 0
 end


### PR DESCRIPTION
Closes #264

Thus, I can set `g:neoterm_repl_r='radian'` in my `init.vim`. 
I didn't want to have the [radian](https://github.com/randy3k/radian) REPL name hardcoded in the source code (something like Python REPL) because the REPL project is renamed a couple of times in the last 3 years.

Let me know if you request any changes.