### PR TITLE
Make `Topen` not create empty buffer if terminal already exists (#285)

### DIFF
--- a/autoload/neoterm.vim
+++ b/autoload/neoterm.vim
@@ -66,7 +66,9 @@ function! neoterm#open(...) abort
     end
 
     let l:instance.origin = neoterm#origin#new()
-    call s:create_window(l:instance)
+    if get(l:instance, 'buffer_id', 0) > 0 && bufnr('') != l:instance.buffer_id
+      exec printf('buffer %s', l:instance.buffer_id)
+    end
     call s:after_open(l:instance)
 
     let g:neoterm.last_active = l:instance.id


### PR DESCRIPTION
The new code which replaces `call s:create_window(l:instance)` stems from the function `create_window` itself. The issue with calling `create_window` directly is that it creates a new empty buffer which is necessary because of issues #236 and #262. It seems to me to be very unintuitive to call `create_window` in the function `neoterm#open` because the elseif-block where its called is not responsible for creating a new window but to exactly avoid this and to switch to an existing terminal instead.