### PR TITLE
Implement 'neoterm_bracketed_paste' option.

### DIFF
--- a/autoload/neoterm/repl.vim
+++ b/autoload/neoterm/repl.vim
@@ -86,6 +86,10 @@ endfunction
 
 function! g:neoterm.repl.exec(command) abort
   let l:ft_exec = printf('neoterm#repl#%s#exec', &filetype)
+  if g:neoterm_bracketed_paste
+    let a:command[0] = "\x1b[200~" . a:command[0]
+    let a:command[-1] = a:command[-1] . "\x1b[201~"
+  endif
   try
     let ExecByFiletype = function(l:ft_exec)
     call ExecByFiletype(a:command)

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -156,6 +156,10 @@ if !exists('g:neoterm_clear_cmd')
   let g:neoterm_clear_cmd = ["\<c-l>"]
 end
 
+if !exists('g:neoterm_bracketed_paste')
+  let g:neoterm_bracketed_paste = 0
+end
+
 " Load the right adapter for vim or neovim
 call neoterm#term#load()
 


### PR DESCRIPTION
This PR is a suggestion for #295 solution. It introduces `g:neoterm_bracketed_paste` setting: value 0 (default) disables bracketed paste (which is exactly the current situation), value 1 enables it.

Here are (many) examples of how this setting works with `neoterm_repl_r` equal to `"radian"` and `"r"` and `neoterm_repl_python` equal to `"ipython"` and `"python"`. In every one of them I execute `TREPLSendFile`, `TREPLSendSelection`, and `TREPLSendLine`:

<details><summary>Examples</summary>
    <details><summary>radian</summary>
Bracketed paste <b>enabled</b> (everything works):
<img src="https://user-images.githubusercontent.com/24854248/88477479-f6986980-cf48-11ea-94eb-dc24d1699de8.gif"><br>
Bracketed paste <b>disabled</b> (only sending single line works with default radian settings):<br>
<img src="https://user-images.githubusercontent.com/24854248/88477482-ff893b00-cf48-11ea-8cd6-5adc108c6350.gif">
    </details>
    <details><summary>R</summary>
Bracketed paste <b>enabled</b> (everything works):
<img src="https://user-images.githubusercontent.com/24854248/88477989-4ed16a80-cf4d-11ea-80e5-7b5d3cd32461.gif"><br>
Bracketed paste <b>disabled</b> (everything works; notice that every line is executed sequentially because '+' is present at its beginning):<br>
<img src="https://user-images.githubusercontent.com/24854248/88478005-6ad50c00-cf4d-11ea-8f18-cca6f6aea96e.gif">
    </details>
    <details><summary>ipython</summary>
Bracketed paste <b>enabled</b> (everything works):
<img src="https://user-images.githubusercontent.com/24854248/88478049-d1f2c080-cf4d-11ea-9d65-0fc7ccff0581.gif"><br>
Bracketed paste <b>disabled</b> (only sending single line works; notice in terminal buffer extra indentation inside function body):<br>
<img src="https://user-images.githubusercontent.com/24854248/88478052-ddde8280-cf4d-11ea-96c2-7ee5df5159df.gif">
    </details>
    <details><summary>python</summary>
Bracketed paste <b>enabled</b> (only sending single line works because Python gives <code>SyntaxError: multiple statements found while compiling a single statement</code>):
<img src="https://user-images.githubusercontent.com/24854248/88478092-3877de80-cf4e-11ea-9d46-3bcd463ee141.gif"><br>
Bracketed paste <b>disabled</b> (everything works):<br>
<img src="https://user-images.githubusercontent.com/24854248/88478099-42014680-cf4e-11ea-9e1f-541d0fac0295.gif">
    </details>
</details>

To sum up, when this setting is on, Neoterm can send multiline code to radian, R, and ipython, but not plain Python (because it can't compile multiple statements).

@kassio, I would really like this PR to be merged, as this seems to be a very crucial addition. If you give green light here (code is correct, names are appropriate), I'll update 'CHANDELOG.md' and 'neoterm.txt' (please, show the place where this setting should go and if there is any extra information you would like me to put there). Thanks.