### PR TITLE
Update documentation with `g:neoterm_bracketed_paste` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 26/07/2020
+  - Add option `g:neoterm_bracketed_paste` to allow sending text to terminal in bracketed paste mode. ([\#295](https://github.com/kassio/neoterm/issues/295))
+
 ### 29/04/2020
   - Add a `shell` option on `neoterm#new` to be able to handle
     `g:neoterm_direct_open_repl` within the repl namespace. ([\#280](https://github.com/kassio/neoterm/issues/280))

--- a/doc/neoterm.txt
+++ b/doc/neoterm.txt
@@ -336,6 +336,14 @@ Sets how to clear the terminal on `:Tclear`. By default it uses the keybinding
 Default value: `["\<c-l>"]`
 To use the clear command set to: `["clear", ""]`
 
+                                                      *g:neoterm_bracketed_paste*
+
+When set to `1` neoterm will send text to the neoterm buffer in bracketed
+paste mode. This is useful to enable sending multiline statements when working
+with some interactive REPL environments (such as radian for R and ipython for
+Python). Note that when used with pure python, can give `SyntaxError: multiple
+statements found while compiling a single statement`.
+Default value: `0`
 
 ===============================================================================
 4. Operators                                                 *neoterm-operators*


### PR DESCRIPTION
This is a followup to #296. It updates documentation with information about `g:neoterm_bracketed_paste` option.