### PR TITLE
Fix creating of extra buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
   - Dynamically set neoterm window size with `:Topen resize=N` and
     `:Ttoggle resize=N`. ([\#289](https://github.com/kassio/neoterm/issues/289))
   - Add a CHANGELOG enforcer action.
+  - Fixes creation of extra buffer. ([\#294](https://github.com/kassio/neoterm/issues/294))
 
 ### 26/07/2020
   - Add option `g:neoterm_bracketed_paste` to allow sending text to terminal in bracketed paste mode. ([\#295](https://github.com/kassio/neoterm/issues/295))

--- a/autoload/neoterm.vim
+++ b/autoload/neoterm.vim
@@ -289,12 +289,10 @@ function! s:create_window(instance) abort
     endif
 
     let &hidden=l:hidden
+  elseif get(a:instance, 'buffer_id', 0) > 0 && bufnr('') != a:instance.buffer_id
+    exec printf('buffer %s', a:instance.buffer_id)
   else
     enew
-  end
-
-  if get(a:instance, 'buffer_id', 0) > 0 && bufnr('') != a:instance.buffer_id
-    exec printf('buffer %s', a:instance.buffer_id)
   end
 endfunction
 


### PR DESCRIPTION
# What is being fixed/added?

When re-opening a neoterm sometimes it creates a new empty buffer.
To avoid that, check for neoterm buffer before falling back to `enew`.

Fixes #294.


- [x] CHANGELOG