### PR TITLE
Add clear default values for neoterm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 28/07/2020
+  - Add clear default values for neoterm.
+
 ### 27/07/2020
   - Dynamically set neoterm window size with `:Topen resize=N` and
     `:Ttoggle resize=N`. ([\#289](https://github.com/kassio/neoterm/issues/289))

--- a/autoload/neoterm.vim
+++ b/autoload/neoterm.vim
@@ -8,19 +8,10 @@
 "        from_event: Set when the neoterm is being created from the TermOpen
 "        event. This enables neoterm to manage every term created on neovim.
 function! neoterm#new(...) abort
-  let l:opts = extend(get(a:, 1, {}), {
-        \ 'handlers': {},
-        \ 'mod': '',
-        \ 'buffer_id': 0,
-        \ 'origin': neoterm#origin#new(),
-        \ 'from_event': 0,
-        \ 'args': '',
-        \ 'shell': g:neoterm_shell
-        \ }, 'keep')
-
+  let l:opts = neoterm#default#opts(get(a:, 1, {}))
   let l:instance = extend(copy(g:neoterm.prototype), l:opts)
 
-  if !l:opts.from_event
+  if !l:instance.from_event
     call s:create_window(l:instance)
   end
 

--- a/autoload/neoterm/default.vim
+++ b/autoload/neoterm/default.vim
@@ -1,0 +1,3 @@
+function! neoterm#default#opts(opts) abort
+  return extend(copy(a:opts), g:neoterm.default_opts, 'keep')
+endfunction

--- a/plugin/neoterm.vim
+++ b/plugin/neoterm.vim
@@ -160,6 +160,16 @@ if !exists('g:neoterm_bracketed_paste')
   let g:neoterm_bracketed_paste = 0
 end
 
+let g:neoterm.default_opts = {
+      \ 'handlers': {},
+      \ 'mod': '',
+      \ 'args': '',
+      \ 'buffer_id': 0,
+      \ 'from_event': v:false,
+      \ 'origin': neoterm#origin#new(),
+      \ 'shell': g:neoterm_shell
+      \ }
+
 " Load the right adapter for vim or neovim
 call neoterm#term#load()
 

--- a/vmtest/default_test.vim
+++ b/vmtest/default_test.vim
@@ -1,0 +1,17 @@
+call vmtest#plugin('neoterm')
+let g:vmtests.neoterm.default = { '_name': 'Default Options Test' }
+
+function! g:vmtests.neoterm.default.test_with_no_given_opts()
+  call assert_equal(
+        \ g:neoterm.default_opts,
+        \ neoterm#default#opts({})
+        \ )
+endfunction
+
+function! g:vmtests.neoterm.default.test_overwrite_default_values_with_given_opts()
+  call assert_equal('vertical', neoterm#default#opts({ 'mod': 'vertical' }).mod)
+endfunction
+
+function! g:vmtests.neoterm.default.test_create_new_opts_with_given_values()
+  call assert_equal('value', neoterm#default#opts({ 'new_key': 'value' }).new_key)
+endfunction


### PR DESCRIPTION
# What is being fixed/added?

Move neoterm default values to the global config `g:neoterm.default_opts` for easier debugging and extension of the plugin.

- [x] CHANGELOG
