### PR TITLE
Add jupyter as a valid python REPL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 23/09/2020
+  - Add `jupyter console` as a valid python REPL.
+
 ### 06/08/2020
   - Fix defaults loading. Defaults must be calculated when used, not before.
     This fix buffer overwriting, due to early `origin` calculation.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ nnoremap <leader>tl :<c-u>exec v:count.'Tclear'<cr>
 * MATLAB: `matlab -nodesktop -nosplash`
 * PARI/GP: `gp`
 * PHP: `g:neoterm_repl_php` and `psysh` and `php`
-* Python: `ipython` and `python`
+* Python: `ipython`, `jupyter console` and `python`
 * R / R Markdown: `R`
 * Racket: `racket`
 * Rails: `bundle exec rails console`

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ au VimEnter,BufRead,BufNewFile *.lfe set filetype=lfe
 
 If you want to use the jupyter console REPL present on your path, you can use
 this configuration in your `init.vim`:
-```
+```vim
 function! Chomp(string)
     return substitute(a:string, '\n\+$', '', '')
 endfunction

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ au VimEnter,BufRead,BufNewFile *.lfe set filetype=lfe
 
 If you want to use the jupyter console REPL present on your path, you can use
 this configuration in your `init.vim`:
-```vim
+```viml
 function! Chomp(string)
     return substitute(a:string, '\n\+$', '', '')
 endfunction

--- a/README.md
+++ b/README.md
@@ -157,6 +157,15 @@ au VimEnter,BufRead,BufNewFile *.lidr set filetype=lidris
 au VimEnter,BufRead,BufNewFile *.lfe set filetype=lfe
 ```
 
+If you want to use the jupyter console REPL present on your path, you can use
+this configuration in your `init.vim`:
+```
+function! Chomp(string)
+    return substitute(a:string, '\n\+$', '', '')
+endfunction
+let g:neoterm_repl_python = Chomp(system('which jupyter')) . ' console'
+```
+
 ## [Contributing](CONTRIBUTING.md)
 ## [Changelog](CHANGELOG.md)
 ## [Documentation](doc/neoterm.txt)

--- a/autoload/neoterm/repl/python.vim
+++ b/autoload/neoterm/repl/python.vim
@@ -7,6 +7,8 @@ function! neoterm#repl#python#is_valid(value) abort
 
   if l:cmd =~# '\<ipython\>'
     return executable('ipython')
+  elseif l:cmd =~# '\<jupyter\>'
+    return executable('jupyter')
   elseif l:cmd =~# '\<python\>'
     return executable('python')
   else


### PR DESCRIPTION
# What is being fixed/added?
The `is_valid` function prevents `jupyter console` being used as a python REPL

- [ x] added `jupyter` to if statement in `is_valid`

