### PR TITLE
Fix bracketed paste after its move to separate function

### DIFF
--- a/autoload/neoterm/repl.vim
+++ b/autoload/neoterm/repl.vim
@@ -102,7 +102,7 @@ function! s:bracketed_paste(command)
   if g:neoterm_bracketed_paste
     let l:command[0] = "\x1b[200~" . l:command[0]
     let l:command[-1] = l:command[-1] . "\x1b[201~"
-  else
-    return l:command
   endif
+
+  return l:command
 endfunction


### PR DESCRIPTION
# What is being fixed/added?
After moving bracketed paste functionality into its own function (in 018f662), it stopped working. This seems to be due to typo, which is resulted into improper return from `s:bracketed_paste()` in case `g:neoterm_bracketed_paste` is true. This PR fixes this.

# Scenarios
Using neoterm with `g:neoterm_bracketed_paste` set to true.

# Screenshots/Gifs

# Reminders
This seems to be a small fix to be included in any of these.
- [ ] CHANGELOG
- [ ] README (if needed)
- [ ] docs (if needed)
