### PR TITLE
Add support for Stata kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 26/05/2021
+  - Add support for [`Stata`](https://www.stata.com/).
+
 ### 01/12/2020
   - Fix neoterm loading on session load.
 ### 30/11/2020

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ nnoremap <leader>tl :<c-u>exec v:count.'Tclear'<cr>
 * Rust: `evcxr`
 * SML: `rlwrap sml` or `sml`
 * Scala: `sbt console`
+* Stata: `stata -q`
 * TCL: `tclsh`
 
 ### Troubleshooting
@@ -165,6 +166,8 @@ function! Chomp(string)
 endfunction
 let g:neoterm_repl_python = Chomp(system('which jupyter')) . ' console'
 ```
+
+Note that the same approach may be used to use Jupyter for R or Stata, provided the appropriate kernels ([IRkernel](https://github.com/IRkernel/IRkernel) and [stata_kernel](https://kylebarron.dev/stata_kernel/)) are installed.
 
 ## [Contributing](CONTRIBUTING.md)
 ## [Changelog](CHANGELOG.md)

--- a/ftdetect/set_repl_cmd.vim
+++ b/ftdetect/set_repl_cmd.vim
@@ -124,6 +124,11 @@ if has('nvim') || has('terminal')
           \ if executable('sbt') |
           \   call neoterm#repl#set('sbt console') |
           \ end
+    " Stata
+    au FileType stata
+          \ if executable('stata') |
+          \   call neoterm#repl#set('stata -q') |
+          \ end
     " Racket
     au FileType racket
           \ if executable('racket') |


### PR DESCRIPTION
The neoterm plugin already provides support for R, Julia and Python builtin REPLs. Add support for Stata command line interface (no batch mode).

This commit should not change behavior.

# What is being fixed/added?

Define a new REPL for [Stata](https://www.stata.com/) console. 

This PR has been tested on Ubuntu 20.04 and macOS Mojave, with Stata 13.

# Scenarios

Same use cases as R, for instance.

It is assumed that users have the executable `stata` available in their path. Usually, one of the many versions of Stata (SE, MP, IC) is symlinked into  `/usr/local/bin` or `/usr/local/stataXX/`, where `XX` stands for Stata version number, as `stata-se` or `stata-mp`. Sometimes, an additional symlink, `stata -> stata-[(mp|se)]`, is automatically created (by the install script or via Stata GUI). This PR assumes that such a link does exist, otherwise it has to be created by the user under his `$HOME` directory or in system-wide PATH. See  #308 for a (probable) related issue.

# Screenshots/Gifs

N/A

# Reminders

- [x] CHANGELOG
- [x] README (if needed)
- [ ] docs (if needed)
