### PR TITLE
Add Janet to set_repl_cmd.vim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 22/07/2021
+  - Add support for [`Janet`](https://janet-lang.org/).
+
 ### 26/05/2021
   - Add support for [`Stata`](https://www.stata.com/).
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ nnoremap <leader>tl :<c-u>exec v:count.'Tclear'<cr>
     using `g:neoterm_repl_octave_qt = 1`
 * Haskell: `ghci`
 * Idris: `idris`
+* Janet: `janet`
 * JavaScript: `node`
 * Java: `java`
 * Julia: `julia`
@@ -144,7 +145,7 @@ nnoremap <leader>tl :<c-u>exec v:count.'Tclear'<cr>
 ### Troubleshooting
 
 Most standard file extensions for the above REPLs are picked up by Neovim/Vim's
-default filetype plugins. However, there are two exceptions:
+default filetype plugins. However, there are three exceptions:
 * Julia `.jl` files, which are detected as `filetipe=lisp`
 * Idris `.idr`, `.lidr` files which are not recognised as any filetype
 * LFE `.lfe` files, which are not recognized as any filetype

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ nnoremap <leader>tl :<c-u>exec v:count.'Tclear'<cr>
 ### Troubleshooting
 
 Most standard file extensions for the above REPLs are picked up by Neovim/Vim's
-default filetype plugins. However, there are three exceptions:
+default filetype plugins. However, there are some exceptions:
 * Julia `.jl` files, which are detected as `filetipe=lisp`
 * Idris `.idr`, `.lidr` files which are not recognised as any filetype
 * LFE `.lfe` files, which are not recognized as any filetype

--- a/ftdetect/set_repl_cmd.vim
+++ b/ftdetect/set_repl_cmd.vim
@@ -144,5 +144,10 @@ if has('nvim') || has('terminal')
           \ if executable('evcxr') |
           \   call neoterm#repl#set('evcxr') |
           \ end
+    " Janet
+    au FileType janet
+         \ if executable('janet') |
+         \    call neoterm#repl#set('janet') |
+         \ end
   aug END
 end


### PR DESCRIPTION
# What is being fixed/added?
Support for the Janet programming language is being added.

# Scenarios
Execute Janet code inside of a REPL, if the Janet executable is present.

# Reminders

- [x] CHANGELOG
- [x] README (if needed)
- [x] docs (if needed)
