### PR TITLE
Fix neoterm newline pipes for elixir

### DIFF
--- a/autoload/neoterm/repl/elixir.vim
+++ b/autoload/neoterm/repl/elixir.vim
@@ -1,0 +1,5 @@
+function! neoterm#repl#elixir#exec(command) abort
+	let JoinNewLinePipes = luaeval('require("newlinepipejoiner").join_newline_pipes')
+	let l:cmd = JoinNewLinePipes(a:command)
+	call g:neoterm.repl.instance().exec(add(l:cmd, g:neoterm_eof))
+endfunction

--- a/lua/newlinepipejoiner.lua
+++ b/lua/newlinepipejoiner.lua
@@ -1,0 +1,24 @@
+local function trim3(s)
+   return s:gsub("^%s+", ""):gsub("%s+$", "")
+end
+local function string_starts(str, start)
+  return (string.sub(str, 1, string.len(start)) == start)
+end
+local function starts_with_pipe_3f(line)
+  return string_starts(trim3(line), "|> ")
+end
+local function join_newline_pipes(lines)
+  local updated_lines = {}
+  for i, line in ipairs(lines) do
+    if starts_with_pipe_3f(line) then
+      local prev_line = table.remove(updated_lines)
+      table.insert(updated_lines, (prev_line .. " " .. line))
+    else
+      table.insert(updated_lines, line)
+    end
+  end
+  return updated_lines
+end
+return {
+	join_newline_pipes = join_newline_pipes,
+}


### PR DESCRIPTION
# What is being fixed/added?
Elixir pipes `|>` that start on newlines are combined with previous lines.

# Scenarios

    foo = "FOO"
    |> String.downcase

on iex(Elixir REPL) will result `foo = "FOO"` despite `downcase` being evaluated the result will not be bound the var `foo`.
This fix will make it `foo = "FOO" |> String.downcase` so that it works on iex

# Screenshots/Gifs

# Reminders

- [ ] CHANGELOG
- [ ] README (if needed)
- [ ] docs (if needed)
