### PR TITLE
ctrl+U

### DIFF
--- a/autoload/neoterm/repl.vim
+++ b/autoload/neoterm/repl.vim
@@ -100,7 +100,7 @@ function! s:bracketed_paste(command)
   let l:command = a:command
 
   if g:neoterm_bracketed_paste
-    let l:command[0] = "\x1b[200~" . l:command[0]
+    let l:command[0] = "\x1b[200~" . l:command[0]
     let l:command[-1] = l:command[-1] . "\x1b[201~"
   endif
 

--- a/autoload/neoterm/term.vim
+++ b/autoload/neoterm/term.vim
@@ -70,5 +70,5 @@ function! s:term.on_exit(...) abort
   if has_key(l:self.handlers, 'on_exit')
     call l:self.handlers['on_exit'](a:)
   end
-  " call neoterm#destroy(l:self)
+  call neoterm#destroy(l:self)
 endfunction

--- a/autoload/neoterm/term.vim
+++ b/autoload/neoterm/term.vim
@@ -70,5 +70,5 @@ function! s:term.on_exit(...) abort
   if has_key(l:self.handlers, 'on_exit')
     call l:self.handlers['on_exit'](a:)
   end
-  call neoterm#destroy(l:self)
+  " call neoterm#destroy(l:self)
 endfunction


### PR DESCRIPTION
# What is being fixed/added?

`TREPLSendLine`, I add "ctrl+U" in `s:bracketed_paste`.

# Scenarios


```python
def sin_expansion(x, n):
    """
    Evaluate the nth order Talyor series expansion
    of sin(x) for the numerical values in the array x.
    """
    return s.lambdify(sym_x, s.sin(sym_x).series(n=n+1).removeO(), 'numpy')(x)
```
If is is executed line by line with `TREPLSendLine`, next line will be auto-indented, and errors will generate because the indents  keep increasing.

Now, with `TREPLSendLine`, the indent will be just the same as command it sends, just like `TREPLSendFile` with bracketed paste mode on.
