### PR TITLE
Support check whether repl has same shell command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 26/04/2022
+  - Add `g:neoterm_repl_same_shell` support. Will try to run repl in
+    term instance with same shell command once enabled.
 ### 27/12/2021
   - Add `g:neoterm_callbacks.before_create_window` support. Custom callback to
     be executed just before a window is created. Useful to dynamically set

--- a/autoload/neoterm/repl.vim
+++ b/autoload/neoterm/repl.vim
@@ -1,11 +1,26 @@
 let g:neoterm.repl = { 'loaded': 0 }
 
+function! s:has_same_shell(shell)
+  if !exists('g:neoterm_repl_same_shell') || g:neoterm_repl_same_shell <= 0
+    return 1
+  endif
+
+  for val in values(g:neoterm.instances)
+    if has_key(val, 'shell') && a:shell == val['shell']
+      return 1
+    endif
+  endfor
+
+  return 0
+endfunction
+
 function! g:neoterm.repl.instance() abort
   if !has_key(l:self, 'instance_id')
-    if !g:neoterm.has_any()
+    let l:shell = s:shell()
+    if !g:neoterm.has_any() || !s:has_same_shell(l:shell)
       call neoterm#new({
             \ 'handlers': neoterm#repl#handlers(),
-            \ 'shell': s:shell()
+            \ 'shell': l:shell
             \ })
     end
 

--- a/doc/neoterm.txt
+++ b/doc/neoterm.txt
@@ -260,6 +260,11 @@ When set, the `%` will always be expanded to the file relative path instead of
 its absolute path.
 Default value: 0
 
+                                                     *g:neoterm_repl_same_shell*
+
+When set, neoterm will send REPL to instance with same shell command.
+Default value: `0`.
+
                                                            *g:neoterm_repl_ruby*
 
 Sets what ruby REPL will be used.


### PR DESCRIPTION
# What is being fixed/added?

Support check whether repl has same shell command with option: `g:neoterm_repl_same_shell`

# Scenarios

For python files, repl commands will always have right shell commands
instead of `zsh` in some cases.

# Screenshots/Gifs

# Reminders

- [x] CHANGELOG
- [x] README (if needed)
- [x] docs (if needed)